### PR TITLE
Sealed type families

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,17 @@
-
 ![Extruder](https://i.imgur.com/yFYmS5q.jpg)
 
 # Extruder
 
 [![Build Status](https://travis-ci.org/janstenpickle/extruder.svg?branch=master)](https://travis-ci.org/janstenpickle/extruder)  [ ![Download](https://api.bintray.com/packages/janstenpickle/maven/extruder/images/download.svg) ](https://bintray.com/janstenpickle/maven/extruder/_latestVersion)
 
-This library uses [shapeless](https://github.com/milessabin/shapeless) and [cats](https://github.com/typelevel/cats) to provide a neat syntax to instantiate Scala case classes from a configuration source. 
+This library uses [shapeless](https://github.com/milessabin/shapeless) and [cats](https://github.com/typelevel/cats) to provide a neat syntax to instantiate Scala case classes from a configuration source.
 
 **Rules for configuration resolution are specified in the declaration of the case class itself:**
 
 ```scala
 case class ApplicationConfig(default: Int = 100, noDefault: String, optional: Option[Double])
 
-val config: ValidatedNel[ValidationFailure, ApplicationConfig] = resolve[ApplicationConfig](Resolvers)
+val config: ValidatedNel[ValidationFailure, ApplicationConfig] = resolve[ApplicationConfig, Resolvers](Resolvers)
 
 ```
 
@@ -21,13 +20,17 @@ In `ApplicationConfig` above `default` will be set to `100`, `noDefault` will ca
 #Contents of This Readme
 
 - [Motivation](#motivation)
+- [Supported Functionality](#supported-functionality)
+- [Unsupported Functionality](#supported-functionality)
+- [Similar Projects](#similar-projects)
 - [Quick Start Guide](#quick-start-guide)
 - [Extending](#extending)
   - [Resolving Configuration](#resolving-configuration)
+- [Participation](#participation)
 
 #Motivation
 
-Learn more about [shapeless](https://github.com/milessabin/shapeless) having read Dave Gurnell's excellent introduction: ["The Type Astronaut's Guide to Shapeless"](http://underscore.io/books/shapeless-guide/).
+To learn more about [shapeless](https://github.com/milessabin/shapeless) having read Dave Gurnell's excellent introduction: ["The Type Astronaut's Guide to Shapeless"](http://underscore.io/books/shapeless-guide/).
 
 Try out [Grafter](https://github.com/zalando/grafter). This project complements applications which use [Grafter](https://github.com/zalando/grafter) or other dependency injection frameworks and techniques by providing a way of resolving values in case classes from a configuration source.
 
@@ -35,9 +38,68 @@ Specifically Grafter requires that all configuration be part single case class t
 
 This is where Extruder comes in, the [example here](examples/src/main/scala/extruder/examples/Grafter.scala) shows how they may be used together.
 
-#Quick Start Guide
 
-##Install with SBT
+#Supported Functionality
+
+- [Parsing of primitive types](core/src/main/scala/extruder/core/Resolvers.scala):
+  - String
+  - Int
+  - Long
+  - Double
+  - Float
+  - Short
+  - Byte
+  - Boolean
+  - URL
+  - Duration
+  - Finite Duration
+- [Case class resolution](#simple-case-class)
+- [Sealed type member resolution (ADTs)](#sealed-type-families)
+- Resolution from multiple configuration sources:
+  - [Simple Map (`Map[String, String]`)](core/src/main/scala/extruder/core/MapResolvers.scala)
+  - [System Properties](core/src/main/scala/extruder/core/SystemPropertiesResolvers.scala)
+  - [Typesafe Config](typesafe/src/main/scala/extruder/typesafe/TypesafeConfigResolvers.scala)
+- [Pluggable configuration backends](#implementing-a-new-set-of-resolvers)
+- [Addition of more types](#extending-an-existing-set-of-resolvers)
+
+# Unsupported Functionality
+
+**Cyclical references**
+```scala
+case class Example(e: Example)
+
+resolve[Example, SystemPropertiesResolvers](SystemPropertiesResolvers) // won't compile
+
+case class NestedOne(n: NestedTwo)
+case class NestedTwo(n: NestedOne)
+
+resolve[NestedOne, SystemPropertiesResolvers](SystemPropertiesResolvers) // won't compile
+```
+
+**Type Parameters on Case Classes**
+
+```scala
+case class Typed[T](t: T)
+
+resolve[Typed[Int], SystemPropertiesResolvers](SystemPropertiesResolvers) // won't compile
+```
+
+# Similar Projects
+
+### PureConfig
+[PureConfig](https://github.com/melrief/pureconfig) uses a similar technique to create case classes from [Typesafe Config](https://github.com/typesafehub/config).
+
+
+- Extruder accumilates configuration resolution errors, so a single invocation will highlight all problems with the configuration source
+- Extruder supports pluggable configuration backends - does not rely on [Typesafe Config](https://github.com/typesafehub/config) by default
+- Pureconfig supports time parsing using `java.time` which Extruder does not out of the box, a date parsing module may be added in the future, until then [custom resolvers may be added](#extending-an-existing-set-of-resolvers)
+- Resolution of Typesafe `ConfigValue`, `ConfigObject` and `ConfigList` is only supported by the Typesafe Config configuration backend, as it is closely tied to Typesafe Config, Pureconfig supports this by default as it is directly tied to Typesafe config
+- Pureconfig supports returning `Map[String, String]`, for the time being Extruder does not support this
+- Extruder supports control of class and parameter name formatting by [overriding a method](#implementing-pathtostring), however Pureconfig supports this via predefined configuration schemes
+
+# Quick Start Guide
+
+## Install with SBT
 Add the following to your sbt `project/plugins.sbt` file:
 ```scala
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
@@ -45,10 +107,10 @@ addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
 Then add the following to your `build.sbt`
 ```scala
 resolvers += Resolver.bintrayRepo("janstenpickle", "maven")
-libraryDependencies += "extruder" %% "extruder" % "0.0.1"
+libraryDependencies += "extruder" %% "extruder" % "0.1.0"
 ```
 
-##Simple Case Class
+## Simple Case Class
 
 ```scala
 import extruder.core.SystemPropertiesResolvers
@@ -56,18 +118,18 @@ import extruder.resolution._
 
 object Main extends App {
   case class Example(defaultedString: String = "default", configuredString: String, optionalString: Option[String])
-  
+
   println(resolve[Example](SystemPropertiesResolvers)) // Invalid(NonEmptyList(ValidationFailure("Could not find configuration at 'example.configuredstring' and no default available", None)))
-  
+
   System.setProperty("example.configuredstring", "configured")
   println(resolve[Example](SystemPropertiesResolvers)) // Valid(Example("default", "configured", None))
-   
+
   System.setProperty("example.optionalsting", "optional")
-  println(resolve[Example](SystemPropertiesResolvers)) // Valid(Example("default", "configured", Some("optional"))) 
+  println(resolve[Example, SystemPropertiesResolvers](SystemPropertiesResolvers)) // Valid(Example("default", "configured", Some("optional")))
 }
 ```
 
-##Nested Case Classes
+## Nested Case Classes
 
 ```scala
 import extruder.core.SystemPropertiesResolvers
@@ -77,46 +139,83 @@ object Main extends App {
   case class Example(a: NestedOne, b: NestedTwo)
   case class NestedOne(value: String, nested: NestedTwo)
   case class NestedTwo(value: String)
-  
+
   System.setProperty("example.a.nestedone.value", "nested-one")
   System.setProperty("example.a.nestedone.nested.nestedtwo.value", "nested-one-nested-two")
   System.setProperty("example.b.nestedtwo.value", "nested-two")
-  
-  // Resolve separate values depending on path to the case class from the top level case class
-  println(resolve[Example](SystemPropertiesResolvers)) // Valid(Example(NestedOne("nested-one", NestedTwo("nested-one-nested-two")), NestedTwo("nested-two"))
-  
-  
-  System.setProperty("nestedone.value", "nested-one")
-  System.setProperty("nestedtwo.value", "nested-two")
-  // Resolve the same values for all instances of the same case class
-  
-  println(resolve[Example].singletons(SystemPropertiesResolvers)) // Valid(Example(NestedOne("nested-one", NestedTwo("nested-two")), NestedTwo("nested-two"))  
+
+  println(resolve[Example, SystemPropertiesResolvers](SystemPropertiesResolvers)) // Valid(Example(NestedOne("nested-one", NestedTwo("nested-one-nested-two")), NestedTwo("nested-two"))
 }
 ```
 
-###Important Caveats
+## Sealed Type Families
 
-**No cyclical references**
 ```scala
-case class Example(e: Example) 
+import extruder.core.SystemPropertiesResolvers
+import extruder.resolution._
 
-resolve[Example] // won't compile
+object TopLevelSealed extends App {
+  sealed trait Sealed
+  case object ExamplObj
+  case class ExampleCC(a: Int)
 
-case class NestedOne(n: NestedTwo)
-case class NestedTwo(n: NestedOne)
+  System.setProperty("type", "ExampleObj")
 
-resolve[NestedOne] // won't compile
+  println(resolve[Example, SystemPropertiesResolvers](SystemPropertiesResolvers)) // Valid(ExampleObj)
+
+  System.setProperty("type", "ExampleCC")
+  System.setProperty("examplecc.a", "1")
+
+  println(resolve[Example, SystemPropertiesResolvers](SystemPropertiesResolvers)) // Valid(ExampleCC(1))
+}
 ```
 
-#Extending
+```scala
+import extruder.core.SystemPropertiesResolvers
+import extruder.resolution._
 
-##Resolving Configuration
+object NestedSealed extends App {
+  sealed trait Sealed
+  case object ExamplObj
+  case class ExampleCC(a: Int)
 
-The core project ships with a [`Resolvers`](core/src/main/scala/extruder/core/Resolvers.scala) trait and an implementation which uses Java system properties as a configuration source, called `SystemPropertiesResolvers` and shown in the examples above.
+  case class Example(a: Sealed)
 
-The `Resolvers` trait is responsible for providing a set of implicit `Resolver` instances for primitive Scala types. These resolvers are used during the case class construction in [`Extruder`](core/src/main/scala/extruder/core/Extruder.scala), if a resolver cannot be found for a certain type then the compiler will error.
+  System.setProperty("example.a.type", "ExampleObj")
 
-###Implementing a new Set of Resolvers
+  println(resolve[Example](SystemPropertiesResolvers)) // Valid(Example(ExampleObj))
+
+  System.setProperty("example.a.type", "ExampleCC")
+  System.setProperty("example.a.examplecc.a", "1")
+
+  println(resolve[Example, SystemPropertiesResolvers](SystemPropertiesResolvers)) // Valid(Example(ExampleCC(1)))
+}
+
+```
+
+# Extending
+
+## Resolving Configuration
+
+The core project ships with a [`Resolvers`](core/src/main/scala/extruder/core/Resolvers.scala) trait and two implementations which use a map of strings and Java system properties as a configuration sources.
+
+The `Resolvers` trait is responsible for providing a set of implicit `Resolver` instances for primitive Scala types. These resolvers are used during the case class construction in [`Extruder`](core/src/main/scala/extruder/core/Extruder.scala), if a resolver cannot be found for a certain type then the compiler will produce an error.
+
+###Naive Implementation - Use a Map
+
+For every simple configuration sources, which can be loaded directly into memory, the most simple possible implementation may be to convert it to a map and pass that to [`MapResolvers`](core/src/main/scala/extruder/core/MapResolvers.scala):
+
+```scala
+import extruder.core.MapResolvers
+
+object MyConfigSourceResolvers {
+  def apply(source: MyConfigSource): MapResolvers = MapResolvers(convertToMap(source))
+
+  def convertToMap(source: MyConfigSource): Map[String, String] = ???
+}
+```
+
+### Implementing a new Set of Resolvers
 
 The `Resolvers` trait assumes your configuration source will simply be providing string values and includes `Resolver` implementations for most Scala primitives, based on the [Mouse library's](https://github.com/benhutchison/mouse) string parsing. Therefore you only have to implement two methods to add a new simple config source:
 
@@ -126,7 +225,7 @@ object MyResolvers extends Resolvers {
   override def lookupValue(path: Seq[String]): ConfigValidation[Option[String]] = ???
   override def lookupList(path: Seq[String]): ConfigValidation[Option[List[String]]] = ???
 }
-```    
+```
 
 Notice both methods accept the parameter `path` which is a `Seq[String]`, this is essentially the long name of the configuration you are trying to resolve. It is made up of the name of the case class and the name of the parameter.
 
@@ -136,7 +235,7 @@ For example `case class Example(a: String, b: Int)` will evaluate to the paths `
 
 What will follow is a break down of the implementation of the [`SystemPropertiesResolver`](core/src/main/scala/extruder/core/SystemPropertiesResolver.scala) provided by the core library.
 
-First create a map from system properties to act as the configuration source, notice that in this implementation we have chosen to be case insensitive by making all the property keys lower case: 
+First create a map from system properties to act as the configuration source, notice that in this implementation we have chosen to be case insensitive by making all the property keys lower case:
 
 ```scala
 val props: Map[String, String] = System.getProperties.asScala.toMap.map { case (k, v) => k.toLowerCase -> v }
@@ -146,12 +245,12 @@ val props: Map[String, String] = System.getProperties.asScala.toMap.map { case (
 The `pathToString` method is used internally for meaningful error messages on failure of config resolution, using it in `resolveConfig` is optional.
 
 Again, we're using case insensitivity here so convert the path to lower case.
-          
+
 ```scala
 override def pathToString(path: Seq[String]): String = path.mkString(".").toLowerCase
-```                                                                                                                                                                       
-#####Implementing `lookupValue`                                                                                                                                                                       
-Note the return type of `lookupValue` is `ConfigValidation[Option[String]]` which expands to `cats.data.ValidatedNel[ValidationFailure, Option[String]]`. This allows for any errors in looking up configuration to be handled differently to the configuration value not being present. For example, a connection error to a remote configuration source should be handled as an `InvalidNel[String]`, where the error message is a string. Whereas the configuration value not being present should be an empty `Option[String]`. 
+```
+##### Implementing `lookupValue`
+Note the return type of `lookupValue` is `ConfigValidation[Option[String]]` which expands to `cats.data.ValidatedNel[ValidationFailure, Option[String]]`. This allows for any errors in looking up configuration to be handled differently to the configuration value not being present. For example, a connection error to a remote configuration source should be handled as an `InvalidNel[String]`, where the error message is a string. Whereas the configuration value not being present should be an empty `Option[String]`.
 
 ```scala
 override def lookupValue(path: Seq[String]): ConfigValidation[Option[String]] = props.get(pathToString(path)).validNel
@@ -172,28 +271,28 @@ override def lookupList(path: Seq[String]): ConfigValidation[Option[List[String]
 
 As this config source does not provide a means of looking up a list we look up the value using `lookupValue` and turn the string inside `ConfigValidation[Option[String]]` into a list of strings, where each element is separated by a `,`.
 
-It is also possible to add some validation when converting the string value to a list: 
+It is also possible to add some validation when converting the string value to a list:
 
 ```scala
 override def lookupList(path: Seq[String]): ConfigValidation[Option[List[String]]] =
   lookupValue(path).fold(
     _.invalid,
-    _.fold[ConfigValidation[Option[List[String]]]](None.validNel)(value => 
+    _.fold[ConfigValidation[Option[List[String]]]](None.validNel)(value =>
       if (value.contains(",")) Some(value.split(",").toList.map(_.trim)).validNel
       else ValidationFailure(
         s"No separator (,) found in value '$value' when attempting to create a list for '${pathToString(path)}'"
       )
-    )                    
+    )
   )
 ```
 
-#####Overriding `listSeparator`
+##### Overriding `listSeparator`
 
 If you are happy with the default implementation of `lookupList`, but want to change the list separator then you can simply override `listSeparator` and set it to anything you like.
 
-###Extending an Existing Set of Resolvers
+### Extending an Existing Set of Resolvers
 
-Say you wanted to add a resolver for a certain type it is possible to extend an existing implementation of `Resolvers` to parse the new type. Below is an example adding a new resolver for `URL`: 
+Say you wanted to add a resolver for a certain type it is possible to extend an existing implementation of `Resolvers` to parse the new type. Below is an example adding a new resolver for `URL`:
 
 ```scala
 import cats.syntax.either._
@@ -207,7 +306,7 @@ class WithURL extends SystemPropertiesResolvers {
 
 ```
 
-#Participation
+# Participation
 
-This project supports the Typelevel [code of conduct](http://typelevel.org/conduct.html) and aims that its channels 
+This project supports the Typelevel [code of conduct](http://typelevel.org/conduct.html) and aims that its channels
 (mailing list, Gitter, github, etc.) to be welcoming environments for everyone.

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 val specs2Ver = "3.8.6"
 
 val commonSettings = Seq(
-  version := "0.0.1",
+  version := "0.1.0",
   organization := "extruder",
   scalaVersion := "2.12.1",
   crossScalaVersions := Seq("2.11.8", "2.12.1"),
@@ -23,7 +23,7 @@ val commonSettings = Seq(
     "-encoding", "UTF-8"
   ),
   publishMavenStyle := true,
-  licenses += ("MIT license", url("http://opensource.org/licenses/MIT")),
+  licenses += ("MIT", url("http://opensource.org/licenses/MIT")),
   homepage := Some(url("https://github.com/janstenpickle/extruder")),
   developers := List(Developer("janstenpickle", "Chris Jansen", "janstenpickle@users.noreply.github.com", url = url("https://github.com/janstepickle"))),
   publishArtifact in Test := false,
@@ -69,7 +69,7 @@ lazy val examples = (project in file("examples")).
       libraryDependencies += "org.zalando" %% "grafter" % "1.3.1",
       publishArtifact := false
     )
-  ).dependsOn(macros)
+  ).dependsOn(macros, typesafe)
 
 lazy val typesafe = (project in file("typesafe")).
   settings (
@@ -79,7 +79,8 @@ lazy val typesafe = (project in file("typesafe")).
       libraryDependencies ++= Seq(
         "com.typesafe" % "config" % "1.3.1",
         "org.specs2" %% "specs2-core" % specs2Ver % "test",
-        "org.specs2" %% "specs2-scalacheck" % specs2Ver % "test"
+        "org.specs2" %% "specs2-scalacheck" % specs2Ver % "test",
+        "org.scalacheck" %% "scalacheck" % "1.13.4" % "test"
       )
     )
   ).dependsOn(core % "compile->compile;test->test")

--- a/core/src/main/scala/extruder/core/MapResolvers.scala
+++ b/core/src/main/scala/extruder/core/MapResolvers.scala
@@ -1,0 +1,16 @@
+package extruder.core
+
+import cats.syntax.validated._
+
+class MapResolvers(config: Map[String, String]) extends Resolvers {
+  lazy val lowerCaseKeysConfig: Map[String, String] = config.map { case (k, v) => k.toLowerCase -> v }
+
+  override def lookupValue(path: Seq[String]): ConfigValidation[Option[String]] =
+    lowerCaseKeysConfig.get(pathToString(path)).validNel
+
+  override def pathToString(path: Seq[String]): String = path.mkString(".").toLowerCase
+}
+
+object MapResolvers {
+  def apply(map: Map[String, String]): MapResolvers = new MapResolvers(map)
+}

--- a/core/src/main/scala/extruder/core/Resolvers.scala
+++ b/core/src/main/scala/extruder/core/Resolvers.scala
@@ -1,16 +1,22 @@
 package extruder.core
 
+import java.net.URL
+
 import cats.data.Validated.{Invalid, Valid}
 import cats.implicits._
 import mouse.string._
+import shapeless.labelled.{FieldType, field}
+import shapeless.syntax.typeable._
+import shapeless.{:+:, CNil, Coproduct, Inl, Inr, Lazy, Typeable, Witness}
 
 import scala.collection.generic.CanBuildFrom
+import scala.concurrent.duration.Duration
+import scala.reflect.ClassTag
 
-trait Resolvers extends Serializable {
+trait Resolvers extends ResolversBase {
   val listSeparator: String = ","
 
   def lookupValue(path: Seq[String]): ConfigValidation[Option[String]]
-  def pathToString(path: Seq[String]): String
   def lookupList(path: Seq[String]): ConfigValidation[Option[List[String]]] =
     lookupValue(path).map(_.map(_.split(listSeparator).toList.map(_.trim)))
 
@@ -22,6 +28,13 @@ trait Resolvers extends Serializable {
   implicit val short: Parser[Short] = _.parseShort
   implicit val byte: Parser[Byte] = _.parseByte
   implicit val boolean: Parser[Boolean] = _.parseBoolean
+  implicit val url: Parser[URL] = url => Either.catchNonFatal(new URL(url))
+  implicit def duration[T <: Duration : Typeable : ClassTag](implicit ct: ClassTag[T]): Parser[T] = dur =>
+    Either.catchNonFatal(Duration(dur)).flatMap(
+      a => Either.fromOption(a.cast[T], new RuntimeException(
+        s"Could not parse value '$dur' as a valid duration for type '${ct.runtimeClass.getSimpleName}'"
+      ))
+    )
 
   implicit def parseType[T](implicit parse: Parser[T]): Resolver[T] =
     Resolver((path, default) => resolveValue(formatParserError(parse, path))(path, default))
@@ -49,9 +62,6 @@ trait Resolvers extends Serializable {
   implicit def optionalCaseClass[T <: Product with Serializable](implicit resolver: Resolver[T]): Resolver[Option[T]] =
     Resolver((path, _) => resolver.read(path, None).map(Some(_)))
 
-  def errorMsg[T](path: Seq[String]): ConfigValidation[T] =
-    ValidationFailure(s"Could not find configuration at '${pathToString(path)}' and no default available")
-
   def resolveValue[T](parser: String => ConfigValidation[T]): (Seq[String], Option[T]) => ConfigValidation[T] =
     resolve[T, String](parser, lookupValue)
 
@@ -69,8 +79,42 @@ trait Resolvers extends Serializable {
 
   def formatParserError[T](parser: Parser[T], path: Seq[String]): String => ConfigValidation[T] = value =>
     parser(value).leftMap(ex =>
-       new ValidationFailure(s"Could not parse value '$value' at '${pathToString(path)}': ${ex.getClass.getName}", Some(ex))
+       new ValidationFailure(s"Could not parse value '$value' at '${pathToString(path)}': ${ex.getMessage}", Some(ex))
     ).toValidatedNel
+}
+
+trait ResolversBase extends Serializable {
+  val typeKey = "type"
+
+  def pathToString(path: Seq[String]): String
+
+  def errorMsg[T](path: Seq[String]): ConfigValidation[T] =
+    ValidationFailure(s"Could not find configuration at '${pathToString(path)}' and no default available")
+
+  def pathWithType(path: Seq[String]): Seq[String] = path :+ typeKey
+
+  def pathToStringWithType(path: Seq[String]): String =
+    pathToString(pathWithType(path))
+
+  // Implicit resolvers for dealing with union types
+
+  implicit val cnil: Resolver[Option[CNil]] = Resolver((path, _) => ValidationFailure(
+    s"Could not find specified implementation of sealed type at configuration path '${pathToStringWithType(path)}'")
+  )
+
+  implicit def ccons[K <: Symbol, H, T <: Coproduct](implicit key: Witness.Aux[K],
+                                                     headResolve: Lazy[Resolver[Option[H]]],
+                                                     tailResolve: Resolver[Option[T]],
+                                                     typeResolver: Resolver[Option[String]]): Resolver[Option[FieldType[K, H] :+: T]] =
+    Resolver((path, _) =>
+      typeResolver.read(pathWithType(path), None) match {
+        case Valid(None) => None.validNel
+        case Valid(Some(tpe)) if tpe == key.value.name =>
+          headResolve.value.read(path, None).map(_.map(v => Inl(field[K](v))))
+        case Valid(_) => tailResolve.read(path, None).map(_.map(Inr(_)))
+        case err @ Invalid(_) => err
+      }
+    )
 }
 
 trait Resolver[T] {
@@ -81,5 +125,10 @@ object Resolver {
   def apply[T](f: (Seq[String], Option[T]) => ConfigValidation[T]) = new Resolver[T] {
     override def read(path: Seq[String],
                       default: Option[T]): ConfigValidation[T] = f(path, default)
+  }
+
+  def apply[T](f: => ConfigValidation[T]) = new Resolver[T] {
+    override def read(path: Seq[String],
+                      default: Option[T]): ConfigValidation[T] = f
   }
 }

--- a/core/src/main/scala/extruder/core/SystemPropertiesResolvers.scala
+++ b/core/src/main/scala/extruder/core/SystemPropertiesResolvers.scala
@@ -1,15 +1,7 @@
 package extruder.core
 
-import cats.syntax.validated._
 import scala.collection.JavaConverters._
 
-class SystemPropertiesResolvers extends Resolvers {
-  def props: Map[String, String] = System.getProperties.asScala.toMap.map { case (k, v) => k.toLowerCase -> v }
-
-  override def lookupValue(path: Seq[String]): ConfigValidation[Option[String]] =
-    props.get(pathToString(path)).validNel
-
-  override def pathToString(path: Seq[String]): String = path.mkString(".").toLowerCase
-}
+class SystemPropertiesResolvers extends MapResolvers(System.getProperties.asScala.toMap)
 
 object SystemPropertiesResolvers extends SystemPropertiesResolvers

--- a/core/src/test/scala/extruder/core/BaseResolversSpec.scala
+++ b/core/src/test/scala/extruder/core/BaseResolversSpec.scala
@@ -1,17 +1,33 @@
 package extruder.core
 
+import java.net.URL
+
+import cats.Show
 import cats.data.NonEmptyList
+import cats.instances.all._
 import org.scalacheck.{Gen, Prop}
 import org.specs2.matcher.{EitherMatchers, MatchResult}
 import org.specs2.specification.core.SpecStructure
 import org.specs2.{ScalaCheck, Specification}
+import shapeless.Typeable
 
-trait BaseResolversSpec extends Specification with EitherMatchers with ScalaCheck {
+import scala.concurrent.duration.{Duration, FiniteDuration}
+
+trait BaseResolversSpec[L] extends Specification with EitherMatchers with ScalaCheck {
   import BaseResolversSpec._
 
+  implicit def showList: Show[L]
   def failingResolvers: Resolvers
-  def successfulResolvers(value: Any): Resolvers
-  def makeList[T](list: List[T]): Any
+  def successfulResolvers[T : Show](value: T): Resolvers
+  def makeList[T](list: List[T]): L
+
+  def ext: SpecStructure = s2""""""
+  implicit val showUrl: Show[URL] = Show.show(_.toString)
+  implicit def showDuration[T <: Duration]: Show[T] = Show.show {
+    case x if x == Duration.Inf => "Inf"
+    case x if x == Duration.MinusInf => "MinusInf"
+    case x => x.toString
+  }
 
   // test is sequential to ensure no concurrent modifications
   override def is: SpecStructure = sequential ^ s2"""
@@ -24,6 +40,9 @@ trait BaseResolversSpec extends Specification with EitherMatchers with ScalaChec
         Short ${succeeding(Gen.posNum[Short], _.short)}
         Byte ${succeeding(Gen.posNum[Byte], _.byte)}
         Boolean ${succeeding(Gen.oneOf(true, false), _.boolean)}
+        URL ${succeeding(urlGen, _.url)}
+        Duration ${succeeding[Duration](durationGen, _.duration)}
+        Finite Duration ${succeeding[FiniteDuration](finiteDurationGen, _.duration)}
 
       Fails when configuration is invalid
         Int ${failing(_.int)}
@@ -33,12 +52,16 @@ trait BaseResolversSpec extends Specification with EitherMatchers with ScalaChec
         Short ${failing(_.short)}
         Byte ${failing(_.byte)}
         Boolean ${failing(_.boolean)}
+        URL ${failing(_.url)}
+        Duration ${failing[Duration](_.duration)}
+        Finite Duration ${failing[FiniteDuration](_.duration)}
 
       When no configuration is available
         Succeeds when there is a default $emptyDefault
         Fails when there is no default $emptyNoDefault
 
       Can handle scala traversable once collections $collections
+      $ext
     """
 
   def collections: Prop =
@@ -66,31 +89,45 @@ trait BaseResolversSpec extends Specification with EitherMatchers with ScalaChec
       a.head === new ValidationFailure("Could not find configuration at 'test' and no default available", None)
     )
 
-  def failing[T](parserSelector: Resolvers => Parser[T]): Prop =
-    tester(Gen.alphaStr, runTest(parserSelector, failure))
+  def failing[T : Show](parserSelector: Resolvers => Parser[T]): Prop =
+    tester(Gen.alphaStr, runTest[T, String](parserSelector, failure))
 
-  def succeeding[T](gen: Gen[T], parserSelector: Resolvers => Parser[T]): Prop =
-    tester(gen.map(_.toString), runTest(parserSelector, success))
+  def succeeding[T : Typeable : Show](gen: Gen[T], parserSelector: Resolvers => Parser[T]): Prop =
+    tester(gen, runTest[T, T](parserSelector, success))
 
-  def tester[T, V](inputGen: Gen[String], test: String => Result[V]): Prop =
-    Prop.forAll(inputGen)(test)
+  def tester[T, V](inputGen: Gen[T], test: T => Result[V]): Prop =
+    Prop.forAllNoShrink(inputGen)(test)
 
-  def success[T]: Test[T] = (result, expected) => result must beRight.which(_.toString === expected)
+  def success[T, V]: Test[T, V] = (result, expected) => result must beRight.which(_ === expected)
 
-  def failure[T]: Test[T] = (result, _) => result must beLeft
+  def failure[T, V]: Test[T, V] = (result, _) => result must beLeft
 
-  def runTest[T](parserSelector: Resolvers => Parser[T], test: Test[T])(expected: String): Result[T] = {
+  def runTest[T, V : Show](parserSelector: Resolvers => Parser[T], test: Test[T, V])(expected: V): Result[T] = {
     val resolvers = successfulResolvers(expected)
     test(testResolve[T](resolvers.parseType(parserSelector(resolvers)), None), expected)
   }
-
 }
 
 object BaseResolversSpec {
   type Result[T] = MatchResult[Either[NonEmptyList[ValidationFailure], T]]
-  type Test[T] = (Either[NonEmptyList[ValidationFailure], T], String) => Result[T]
+  type Test[T, V] = (Either[NonEmptyList[ValidationFailure], T], V) => Result[T]
 
   val testKey: String = "test"
+
+  val nonEmptyStringGen: Gen[String] = Gen.alphaNumStr.suchThat(_.nonEmpty)
+
+  val urlGen: Gen[URL] = for {
+    host <- nonEmptyStringGen
+    path <- nonEmptyStringGen
+  } yield new URL(s"http://$host/$path")
+
+  val durationGen: Gen[Duration] = Gen.oneOf(
+    Gen.choose(Long.MinValue + 1, Long.MaxValue).map(Duration.fromNanos),
+    Gen.const(Duration.Inf),
+    Gen.const(Duration.MinusInf)
+  )
+
+  val finiteDurationGen: Gen[FiniteDuration] = Gen.chooseNum(0L, Long.MaxValue).map(Duration.fromNanos)
 
   def testResolve[T](resolver: Resolver[T], default: Option[T]): Either[NonEmptyList[ValidationFailure], T] =
     resolver.read(Seq(testKey), default).toEither

--- a/core/src/test/scala/extruder/core/MapResolversSpec.scala
+++ b/core/src/test/scala/extruder/core/MapResolversSpec.scala
@@ -1,0 +1,16 @@
+package extruder.core
+
+import cats.Show
+import cats.syntax.show._
+
+class MapResolversSpec extends BaseResolversSpec[String] {
+  import BaseResolversSpec._
+
+  override def failingResolvers: Resolvers = MapResolvers(Map.empty)
+
+  override def successfulResolvers[T : Show](value: T): Resolvers = MapResolvers(Map(testKey -> value.show))
+
+  override def makeList[T](list: List[T]): String = list.mkString(",")
+
+  override implicit val showList: Show[String] = Show.show(identity)
+}

--- a/core/src/test/scala/extruder/core/ResolversSpec.scala
+++ b/core/src/test/scala/extruder/core/ResolversSpec.scala
@@ -1,18 +1,23 @@
 package extruder.core
 
+import cats.Show
 import cats.syntax.validated._
+import cats.syntax.show._
 
-class ResolversSpec extends BaseResolversSpec {
+class ResolversSpec extends BaseResolversSpec[String] {
 
   override val failingResolvers: Resolvers = new Resolvers {
     override def pathToString(path: Seq[String]): String = path.mkString("").toLowerCase
     override def lookupValue(path: Seq[String]): ConfigValidation[Option[String]] = None.validNel
   }
 
-  override def successfulResolvers(value: Any): Resolvers = new Resolvers {
+  override def successfulResolvers[T : Show](value: T): Resolvers = new Resolvers {
     override def pathToString(path: Seq[String]): String = ""
-    override def lookupValue(path: Seq[String]): ConfigValidation[Option[String]] = Some(value.toString).validNel
+    override def lookupValue(path: Seq[String]): ConfigValidation[Option[String]] = Some(value.show).validNel
   }
 
-  override def makeList[T](list: List[T]): Any = list.mkString(",")
+  override def makeList[T](list: List[T]): String = list.mkString(",")
+
+
+  override implicit val showList: Show[String] = Show.show(identity)
 }

--- a/core/src/test/scala/extruder/core/SystemPropertiesResolversSpec.scala
+++ b/core/src/test/scala/extruder/core/SystemPropertiesResolversSpec.scala
@@ -1,6 +1,9 @@
 package extruder.core
 
-class SystemPropertiesResolversSpec extends BaseResolversSpec {
+import cats.Show
+import cats.syntax.show._
+
+class SystemPropertiesResolversSpec extends BaseResolversSpec[String] {
   import BaseResolversSpec._
 
   override def failingResolvers: Resolvers = {
@@ -8,10 +11,12 @@ class SystemPropertiesResolversSpec extends BaseResolversSpec {
     new SystemPropertiesResolvers
   }
 
-  override def successfulResolvers(value: Any): Resolvers = {
-    System.setProperty(testKey, value.toString)
+  override def successfulResolvers[T : Show](value: T): Resolvers = {
+    System.setProperty(testKey, value.show)
     new SystemPropertiesResolvers
   }
 
-  override def makeList[T](list: List[T]): Any = list.mkString(",")
+  override def makeList[T](list: List[T]): String = list.mkString(",")
+
+  override implicit val showList: Show[String] = Show.show(identity)
 }

--- a/examples/src/main/scala/extruder/examples/Grafter.scala
+++ b/examples/src/main/scala/extruder/examples/Grafter.scala
@@ -52,7 +52,7 @@ object Grafter extends App {
       failure.exception.fold[StartResult](StartFailure(failure.message))(ex => StartError(failure.message, ex))
     ))
 
-  val start: Eval[List[StartResult]] = resolve[ApplicationConfig](SystemPropertiesResolvers)
+  val start: Eval[List[StartResult]] = resolve[ApplicationConfig, SystemPropertiesResolvers](SystemPropertiesResolvers)
     .fold(convertToStartResult, app => Rewriter.start(GenericReader[ApplicationConfig, Application].run(app)))
 
   println(start.value)

--- a/examples/src/main/scala/extruder/examples/Simple.scala
+++ b/examples/src/main/scala/extruder/examples/Simple.scala
@@ -1,27 +1,40 @@
 package extruder.examples
 
-import extruder.core.SystemPropertiesResolvers
+import extruder.core.MapResolvers
 import extruder.resolution._
 
-import scala.util.Try
+import scala.concurrent.duration.{Duration, FiniteDuration}
 
-case class CC(a: String = "test", b: String = "test2", c: Int, d: Option[CC2], e: CC3, f: Set[Int])
-
+case class CC(a: String = "test", b: String = "test2", c: Int, d: Option[CC2], e: CC3, f: Set[Int], dur: Duration, finDur: FiniteDuration)
 case class CC2(x: String = "test4", y: Option[Int] = Some(232), z: CC3)
-
-case class CC3(a: Option[String]) {
-  val tryA: Try[String] = Try(a.get)
-}
-
+case class CC3(a: Option[String])
 case class CC4(a: Option[CC3])
 
-object Simple extends App {
-  System.setProperty("cc.c", "2000")
-  System.setProperty("cc.e.cc3.a", "test3")
-  System.setProperty("cc.d.cc2.z.cc3.a", "shit")
-  System.setProperty("cc3.a", "hello")
-  System.setProperty("cc.f", "2, 3")
+sealed trait Sealed
+case object ObjImpl extends Sealed
+case class CCImpl(a: String) extends Sealed
 
-  println(resolve[CC](SystemPropertiesResolvers))
-  println(resolve[CC4].singletons(SystemPropertiesResolvers))
+object Simple extends App {
+  val ccResolvers = MapResolvers(Map(
+    "cc.c" -> "2000",
+    "cc.e.cc3.a" -> "test3",
+    "cc.d.cc2.z.cc3.a" -> "testing",
+    "cc3.a" -> "hello",
+    "cc.f" -> "2, 3",
+    "cc.dur" -> "Inf",
+    "cc.findur" -> "22 days"
+  ))
+
+  println(resolve[CC, MapResolvers](ccResolvers))
+
+  val sealedCCResolvers = MapResolvers(Map(
+    "type" -> "CCImpl",
+    "ccimpl.a" -> "testing"
+  ))
+
+  println(resolve[Sealed, MapResolvers](sealedCCResolvers))
+
+ val sealedObjResolvers = MapResolvers(Map("type" -> "ObjImpl"))
+
+  println(resolve[Sealed, MapResolvers](sealedObjResolvers))
 }

--- a/typesafe/src/test/scala/extruder/typesafe/TypesafeConfigResolversSpec.scala
+++ b/typesafe/src/test/scala/extruder/typesafe/TypesafeConfigResolversSpec.scala
@@ -1,18 +1,66 @@
 package extruder.typesafe
 
-import com.typesafe.config.ConfigFactory
+import java.net.URL
+import java.util
+
+import cats.Show
+import cats.instances.all._
+import cats.syntax.show._
+import com.typesafe.config.{ConfigFactory, ConfigList, ConfigObject, ConfigValue}
 import extruder.core.{BaseResolversSpec, Resolvers}
+import org.scalacheck.{Gen, Prop}
+import org.specs2.specification.core.SpecStructure
 
 import scala.collection.JavaConverters._
+import scala.concurrent.duration.Duration
 
-class TypesafeConfigResolversSpec extends BaseResolversSpec {
+class TypesafeConfigResolversSpec extends BaseResolversSpec[java.util.List[String]] {
   import BaseResolversSpec._
+  import TypesafeConfigResolversSpec._
+
+  override implicit def showList: Show[util.List[String]] = Show.show(_.toString)
+
+  implicit val showMap: Show[java.util.Map[String, String]] = Show.show(_.toString)
 
   override val failingResolvers: Resolvers =
     TypesafeConfigResolvers(ConfigFactory.parseMap(Map.empty[String, Any].asJava))
 
-  override def successfulResolvers(value: Any): Resolvers =
-    TypesafeConfigResolvers(ConfigFactory.parseMap(Map(testKey -> value).asJava))
+  def maybeShow[T : Show](value: T): Any = value match {
+    case _: URL => value.show
+    case _: Duration => value.show
+    case _ => value
+  }
 
-  override def makeList[T](list: List[T]): Any = list.asJava
+  override def successfulResolvers[T : Show](value: T): TypesafeConfigResolvers =
+    TypesafeConfigResolvers(ConfigFactory.parseMap(Map(testKey -> maybeShow(value)).asJava))
+
+  override def makeList[T](list: List[T]): java.util.List[String] = list.map(_.toString).asJava
+
+  override def ext: SpecStructure =
+    s2"""
+      Typesafe specific types
+        Can resolve ConfigValue $configValue
+        Can resolve ConfigList $configList
+        Can resolve ConfigObject $configObject
+      """
+
+  def configValue: Prop = Prop.forAll(Gen.alphaNumStr) (value =>
+    testResolve[ConfigValue](successfulResolvers(value).configValueResolver, None) must beRight.
+      which(_.unwrapped() === value)
+  )
+
+  def configList: Prop = Prop.forAll(Gen.listOf(Gen.alphaNumStr))(value =>
+    testResolve[ConfigList](successfulResolvers(value.asJava).configListResolver, None) must beRight.
+      which(_.unwrapped().asScala.toList === value)
+  )
+
+
+  def configObject: Prop = Prop.forAll(Gen.mapOf(nonEmptyString.map(s => (s, s))))(value =>
+    testResolve[ConfigObject](successfulResolvers(value.asJava).configObjectResolver, None) must beRight.
+      which(_.unwrapped().asScala.toMap === value)
+  )
+}
+
+object TypesafeConfigResolversSpec {
+  val nonEmptyString: Gen[String] = Gen.alphaNumStr.suchThat(_.nonEmpty)
 }


### PR DESCRIPTION
- add support for sealed type families via shapeless' coproduct
- modify macro to cope with sealed type families
- support URL, Duration and FiniteDuration as primitive types
- support typesafe config types in the typesafe resolvers
- update docs