### PR TITLE
Add ability to display find and display required params

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This library uses [shapeless](https://github.com/milessabin/shapeless) and [cats
 
 **Rules for configuration resolution are specified in the declaration of the case class itself:**
 ```scala
-import extruder.core.SystemPropertiesConfig._
+import extruder.system.SystemPropertiesConfig._
 
 case class ApplicationConfig(default: Int = 100, noDefault: String, optional: Option[Double])
 
@@ -38,20 +38,16 @@ In `ApplicationConfig` above `default` will be set to `100`, `noDefault` will ca
 
 
 ## Install with SBT
-Add the following to your sbt `project/plugins.sbt` file:
-```scala
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
-```
-Then add the following to your `build.sbt`:
+Add the following to your `build.sbt`:
 ```scala
 resolvers += Resolver.bintrayRepo("janstenpickle", "maven")
-libraryDependencies += "extruder" %% "extruder" % "0.3.1"
+libraryDependencies += "extruder" %% "extruder" % "0.4.0"
 
 // only if you require support for Typesafe config
-libraryDependencies += "extruder" %% "extruder-typesafe" % "0.3.1"
+libraryDependencies += "extruder" %% "extruder-typesafe" % "0.4.0"
 
 // only if you require support for refined types
-libraryDependencies += "extruder" %% "extruder-refined" % "0.3.1"
+libraryDependencies += "extruder" %% "extruder-refined" % "0.4.0"
 ```
 
 # Motivation
@@ -94,7 +90,7 @@ This is where Extruder comes in, the [example here](examples/src/main/scala/extr
 
 **Cyclical references**
 ```scala
-import extruder.core.SystemPropertiesConfig._
+import extruder.system.SystemPropertiesConfig._
 
 case class Example(e: Example)
 
@@ -124,7 +120,7 @@ decode[NestedOne] // won't compile
 ## Simple Case Class
 
 ```scala
-import extruder.core.SystemPropertiesConfig._
+import extruder.system.SystemPropertiesConfig._
 
 object Main extends App {
   case class Example(defaultedString: String = "default", configuredString: String, optionalString: Option[String])
@@ -142,7 +138,7 @@ object Main extends App {
 ## Nested Case Classes
 
 ```scala
-import extruder.core.SystemPropertiesConfig._
+import extruder.system.SystemPropertiesConfig._
 
 object Main extends App {
   case class Example(a: NestedOne, b: NestedTwo)
@@ -159,7 +155,7 @@ object Main extends App {
 ## Sealed Type Families
 
 ```scala
-import extruder.core.SystemPropertiesResolvers
+import extruder.system.SystemPropertiesResolvers
 import extruder.resolution._
 
 object TopLevelSealed extends App {
@@ -179,7 +175,7 @@ object TopLevelSealed extends App {
 ```
 
 ```scala
-import extruder.core.SystemPropertiesResolvers
+import extruder.system.SystemPropertiesResolvers
 import extruder.resolution._
 
 object NestedSealed extends App {

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 val specs2Ver = "3.8.6"
 
 val commonSettings = Seq(
-  version := "0.3.2-SNAPSHOT",
+  version := "0.4.0-SNAPSHOT",
   organization := "extruder",
   scalaVersion := "2.12.2",
   crossScalaVersions := Seq("2.11.11", "2.12.2"),
@@ -48,6 +48,11 @@ lazy val core = (project in file("core")).
     )
   )
 
+lazy val systemSources = (project in file("system-sources")).
+  settings (
+    commonSettings ++ Seq(name := "extruder-system-sources")
+  ).dependsOn(core)
+
 lazy val examples = (project in file("examples")).
   settings (
     commonSettings ++
@@ -56,7 +61,7 @@ lazy val examples = (project in file("examples")).
       libraryDependencies ++= Seq("org.zalando" %% "grafter" % "1.4.8"),
       publishArtifact := false
     )
-  ).dependsOn(typesafe, refined)
+  ).dependsOn(systemSources, typesafe, refined)
 
 lazy val typesafe = (project in file("typesafe")).
   settings (
@@ -94,13 +99,12 @@ lazy val root = (project in file(".")).
       name := "extruder",
       unmanagedSourceDirectories in Compile := unmanagedSourceDirectories.all(aggregateCompile).value.flatten,
       sources in Compile  := sources.all(aggregateCompile).value.flatten,
-      libraryDependencies := libraryDependencies.all(aggregateCompile).value.flatten,
-      coverageEnabled := false
+      libraryDependencies := libraryDependencies.all(aggregateCompile).value.flatten
     )
   ).aggregate(core, typesafe, refined)
 
 lazy val aggregateCompile =
   ScopeFilter(
-    inProjects(core),
+    inProjects(core, systemSources),
     inConfigurations(Compile)
   )

--- a/core/src/main/scala/extruder/core/Decoders.scala
+++ b/core/src/main/scala/extruder/core/Decoders.scala
@@ -8,7 +8,7 @@ trait Decoders[C, D[T] <: Decoder[T, C]] {
   def apply[T](implicit decoder: D[T]): D[T] = decoder
 }
 
-trait Decode[C, I, D[T] <: Decoder[T, I]] {
+trait Decode[C, I, D[T] <: Decoder[T, I]] { self: ResolutionCommon =>
   protected def prepareConfig(config: C): ConfigValidation[I]
 
   def decode[T](config: C)(implicit decoder: D[T]): ConfigValidation[T] =
@@ -16,6 +16,12 @@ trait Decode[C, I, D[T] <: Decoder[T, I]] {
 
   def decode[T](namespace: Seq[String], config: C)(implicit decoder: D[T]): ConfigValidation[T] =
     prepareConfig(config).fold(_.invalid, c => decoder.read(namespace, None, c))
+
+  def parameters[T](implicit params: Parameters[T]): String =
+    parameters(Seq.empty[String])
+
+  def parameters[T](namespace: Seq[String])(implicit params: Parameters[T]): String =
+    FormatParameters.asTable[T](pathToString, namespace)
 }
 
 trait Decoder[T, C] {

--- a/core/src/main/scala/extruder/core/DerivedDecoders.scala
+++ b/core/src/main/scala/extruder/core/DerivedDecoders.scala
@@ -18,9 +18,9 @@ trait DerivedDecoders[C, D[T] <: Decoder[T, C]] extends ResolutionCommon { self:
   ).invalidNel)
 
   implicit def cconsDecoder[K <: Symbol, H, T <: Coproduct](implicit key: Witness.Aux[K],
-                                                     headResolve: Lazy[D[H]],
-                                                     tailResolve: Lazy[D[T]],
-                                                     typeResolver: Lazy[D[Option[String]]]): D[FieldType[K, H] :+: T] =
+                                                            headResolve: Lazy[D[H]],
+                                                            tailResolve: Lazy[D[T]],
+                                                            typeResolver: Lazy[D[Option[String]]]): D[FieldType[K, H] :+: T] =
       mkDecoder((path, _, config) =>
       typeResolver.value.read(pathWithType(path), None, config) match {
         case Valid(None) => Missing(
@@ -37,7 +37,7 @@ trait DerivedDecoders[C, D[T] <: Decoder[T, C]] extends ResolutionCommon { self:
                                                underlying: Lazy[D[V]]): D[T] =
     mkDecoder((path, _, config) => underlying.value.read(path, None, config).map(gen.from))
 
-  // scalastyle:off
+  // scalastyle:off parameter.number
   implicit def productDecoder[T,
                               GenRepr <: HList,
                               DefaultOptsRepr <: HList,
@@ -78,7 +78,7 @@ trait DerivedDecoders[C, D[T] <: Decoder[T, C]] extends ResolutionCommon { self:
 }
 
 object DerivedDecoders {
-  // scalastyle:off
+  // scalastyle:off object.name
   object folder extends Poly2 {
     implicit def caseHList[A, B <: HList]: Case.Aux[ConfigValidation[A], ConfigValidation[B], ConfigValidation[A :: B]] =
       at[ConfigValidation[A], ConfigValidation[B]]((a, b) => (a |@| b).map(_ :: _))

--- a/core/src/main/scala/extruder/core/FormatParameters.scala
+++ b/core/src/main/scala/extruder/core/FormatParameters.scala
@@ -1,0 +1,43 @@
+package extruder.core
+
+object FormatParameters {
+  private val KeyCol = "Key"
+  private val RequiredCol = "Required"
+  private val TypeCol = "Type"
+  private val DefaultCol = "Default"
+  private val TypesCol = "Permitted Values"
+
+  private def convertRequired(required: Boolean): String =
+    if (required) "Y" else "N"
+
+  private def colSep(length: Int): String =
+    List.fill(length + 2)('-').mkString
+
+  def maxLength(colName: String, selector: ParamRepr => String, params: List[ParamRepr]): Int =
+    (colName.length :: params.map(p => selector(p).length)).max
+
+  val typesToString: ParamRepr => String = {
+    case union: UnionRepr => union.types.toList.mkString(" | ")
+    case _: Any => ""
+  }
+
+  def asTable[T](pathToString: Seq[String] => String, namespace: Seq[String])(implicit parameters: Parameters[T]): String = {
+    val params = parameters.eval(namespace)
+    val maxKeyLength = maxLength(KeyCol, p => pathToString(p.path), params)
+    val maxRequiredLength = maxLength(RequiredCol, p => convertRequired(p.required), params)
+    val maxTypeLength = maxLength(TypeCol, _.`type`, params)
+    val maxDefaultLength = maxLength(DefaultCol, _.default.getOrElse(""), params)
+    val maxAllowedValuesLength = maxLength(TypesCol, typesToString, params)
+
+    val leftAlignFormat: String =
+      s"| %-${maxKeyLength}s | %-${maxRequiredLength}s | %-${maxTypeLength}s | %-${maxDefaultLength}s | %-${maxAllowedValuesLength}s |%n"
+    val separator: String =
+      s"+${colSep(maxKeyLength)}+${colSep(maxRequiredLength)}+${colSep(maxTypeLength)}+${colSep(maxDefaultLength)}+${colSep(maxAllowedValuesLength)}+%n"
+
+    val header = separator + leftAlignFormat.format(KeyCol, RequiredCol, TypeCol, DefaultCol, TypesCol) + separator
+    val rows = params.foldLeft("")((acc, p) => acc + leftAlignFormat.format(
+      pathToString(p.path), convertRequired(p.required), p.`type`, p.default.getOrElse(""), typesToString(p)
+    ))
+    (header + rows + separator).format()
+  }
+}

--- a/core/src/main/scala/extruder/core/ParametersInstances.scala
+++ b/core/src/main/scala/extruder/core/ParametersInstances.scala
@@ -1,0 +1,171 @@
+package extruder.core
+
+import cats.data.NonEmptyList
+import shapeless.labelled.FieldType
+import shapeless._
+import shapeless.ops.hlist.{ConstMapper, Mapper, RightFolder, Zip}
+import shapeless.ops.record.Keys
+
+import scala.collection.TraversableOnce
+import scala.reflect.runtime.universe.TypeTag
+
+trait ParametersInstances extends Shows {
+
+  implicit def objectParameters[T](implicit gen: Generic.Aux[T, HNil], tag: TypeTag[T]): Parameters[T] =
+    Parameters(_ => List.empty)
+
+  implicit val cnilParameters: Parameters[CNil] = new Parameters[CNil](_ => List.empty)
+
+  implicit def cconsParameters[K <: Symbol, H, T <: Coproduct](implicit key: Witness.Aux[K],
+                                                               headParams: Lazy[Parameters[H]],
+                                                               tailParams: Lazy[Parameters[T]]): Parameters[FieldType[K, H] :+: T] =
+    Parameters(path =>
+      headParams.value.eval(path) ++
+      tailParams.value.eval(path)
+    )
+
+  implicit val cnilTypeName: TypeNames[CNil] = TypeNames(List.empty)
+
+  implicit def cconsTypeNames[K <: Symbol, H, T <: Coproduct](implicit key: Witness.Aux[K],
+                                                              headType: TypeTag[H],
+                                                              tailTypes: Lazy[TypeNames[T]]): TypeNames[FieldType[K, H] :+: T] =
+    TypeNames(ttToString[H] :: tailTypes.value.values)
+
+  implicit def unionParameters[T, V <: Coproduct](implicit gen: LabelledGeneric.Aux[T, V],
+                                                  underlying: Lazy[Parameters[V]],
+                                                  typeNames: Lazy[TypeNames[V]],
+                                                  tag: TypeTag[T]): Parameters[T] =
+    Parameters(path =>
+      NonEmptyList.fromList(typeNames.value.values).fold[List[ParamRepr]](List.empty)(types =>
+        UnionRepr(path :+ ResolutionCommon.TypeKey, types) ::
+        underlying.value.eval(path)
+      )
+    )
+
+  implicit def optionParameters[T](implicit getMeAConfigPath: Parameters[T]): Parameters[Option[T]] =
+    new Parameters[Option[T]](path => getMeAConfigPath.eval(path).map(_.updateRequired(false)))
+
+  // scalastyle:off parameter.number
+  implicit def productParameters[T,
+                                 DefaultOptsRepr <: HList,
+                                 LGenRepr <: HList,
+                                 KeysRepr <: HList,
+                                 ConstRepr <: HList,
+                                 ZipperRepr <: HList,
+                                 PrefixZipperRepr <: HList,
+                                 MapperRepr <: HList](implicit
+                                                      defaultOpts: Default.AsOptions.Aux[T, DefaultOptsRepr],
+                                                      lGen: LabelledGeneric.Aux[T, LGenRepr],
+                                                      keys: Keys.Aux[LGenRepr, KeysRepr],
+                                                      constMapper: ConstMapper.Aux[Seq[String], KeysRepr, ConstRepr],
+                                                      prefixZipper: Zip.Aux[KeysRepr :: ConstRepr :: HNil, PrefixZipperRepr],
+                                                      zipper: Zip.Aux[PrefixZipperRepr :: DefaultOptsRepr :: HNil, ZipperRepr],
+                                                      lazyMapper: Lazy[Mapper.Aux[readParams.type, ZipperRepr, MapperRepr]],
+                                                      rightFolder: RightFolder.Aux[MapperRepr, List[ParamRepr], folder.type, List[ParamRepr]],
+                                                      tag: TypeTag[T]): Parameters[T] = Parameters { path =>
+    lazy val className: String = ttToString[T]
+    val keyNames = Keys[LGenRepr].apply()
+
+    keyNames
+      .zip(keyNames.mapConst(path :+ className))
+      .zip(Default.AsOptions[T].apply())
+      .map(readParams)(lazyMapper.value)
+      .foldRight(List.empty[ParamRepr])(folder)
+  }
+  // scalastyle:on
+
+  // scalastyle:off object.name
+  object readParams extends Poly1 {
+    implicit def casePrimitive[A <: Symbol, B](implicit show: Lazy[Show[B]],
+                                               tag: TypeTag[B]): Case.Aux[((A, Seq[String]), Option[B]), List[ParamRepr]] =
+      at[((A, Seq[String]), Option[B])]{ case ((key, prefix), default) => List(StableRepr(
+        prefix :+ key.name,
+        default.isEmpty,
+        ttToString[B],
+        default.map(show.value.show))
+      )}
+
+    implicit def caseOptionalPrimitive[A <: Symbol, B](implicit show: Lazy[Show[B]],
+                                                       tag: TypeTag[B]):
+    Case.Aux[((A, Seq[String]), Option[Option[B]]), List[ParamRepr]] =
+      at[((A, Seq[String]), Option[Option[B]])]{ case ((key, prefix), default) => List(StableRepr(
+        prefix :+ key.name,
+        required = false,
+        ttToString[B],
+        default.flatten.map(show.value.show))
+      )}
+
+    implicit def caseProduct[A <: Symbol, B](implicit show: Lazy[Parameters[B]]): Case.Aux[((A, Seq[String]), Option[B]), List[ParamRepr]] =
+      at[((A, Seq[String]), Option[B])]{ case ((key, prefix), _) => show.value.eval(prefix :+ key.name) }
+
+    implicit def caseTraversable[A <: Symbol, B, F[C] <: TraversableOnce[C]](implicit show: Lazy[Show[B]],
+                                                                             tag: TypeTag[B], traversableTag:
+                                                                             TypeTag[F[B]]):
+    Case.Aux[((A, Seq[String]), Option[F[B]]), List[ParamRepr]] =
+      at[((A, Seq[String]), Option[F[B]])]{ case ((key, prefix), default) => List(StableRepr(
+        prefix :+ key.name,
+        default.isEmpty,
+        traversableTtToString[B, F],
+        optTraversableToString(default)
+      ))}
+
+    implicit def caseOptionTraversable[A <: Symbol, B, F[C] <: TraversableOnce[C]](implicit show: Lazy[Show[B]],
+                                                                                   tag: TypeTag[B],
+                                                                                   traversableTag: TypeTag[F[B]]):
+    Case.Aux[((A, Seq[String]), Option[Option[F[B]]]), List[ParamRepr]] =
+      at[((A, Seq[String]), Option[Option[F[B]]])]{ case ((key, prefix), default) => List(StableRepr(
+        prefix :+ key.name,
+        required = false,
+        traversableTtToString[B, F],
+        optTraversableToString(default.flatten)
+      ))}
+
+  }
+
+  object folder extends Poly2 {
+    implicit val caseHList: Case.Aux[List[ParamRepr], List[ParamRepr], List[ParamRepr]] =
+      at[List[ParamRepr], List[ParamRepr]]((a, b) => a ++ b)
+  }
+  // scalastyle:on
+
+  def optTraversableToString[A, F[B] <: TraversableOnce[B]](opt: Option[F[A]])(implicit show: Lazy[Show[A]]): Option[String] =
+    opt.map(_.map(show.value.show).mkString(", "))
+
+  def ttToString[A](implicit tag: TypeTag[A]): String = tag.tpe.typeSymbol.name.toString
+
+  def traversableTtToString[A, F[B] <: TraversableOnce[B]](implicit tag: TypeTag[A], traversableTag: TypeTag[F[A]]): String =
+    s"${ttToString[F[A]]}[${ttToString[A]}]"
+}
+
+case class Parameters[T](eval: Seq[String] => List[ParamRepr])
+
+object Parameters extends ParametersInstances {
+  def apply[T](implicit params: Parameters[T]): Parameters[T] = params
+}
+
+case class TypeNames[T](values: List[String])
+
+object TypeNames extends ParametersInstances {
+  def apply[T](implicit typeNames: TypeNames[T]): TypeNames[T] = typeNames
+}
+
+trait ParamRepr {
+  def path: Seq[String]
+  def required: Boolean
+  def default: Option[String]
+  def updateRequired(req: Boolean): ParamRepr
+  def `type`: String
+}
+
+case class StableRepr(path: Seq[String], required: Boolean, `type`: String, default: Option[String]) extends ParamRepr {
+  override def updateRequired(req: Boolean): StableRepr = copy(required = req)
+}
+
+case class UnionRepr(path: Seq[String], types: NonEmptyList[String]) extends ParamRepr {
+  override val required: Boolean = true
+  override val default: Option[String] = None
+  override val `type`: String = "String"
+  override def updateRequired(req: Boolean): UnionRepr = this
+}
+
+

--- a/core/src/main/scala/extruder/core/ResolutionCommon.scala
+++ b/core/src/main/scala/extruder/core/ResolutionCommon.scala
@@ -3,7 +3,7 @@ package extruder.core
 import cats.syntax.validated._
 
 trait ResolutionCommon extends Serializable {
-  val TypeKey = "type"
+  import ResolutionCommon._
 
   val ListSeparator: String = ","
 
@@ -16,4 +16,8 @@ trait ResolutionCommon extends Serializable {
 
   protected def errorMsg[T](path: Seq[String]): ConfigValidation[T] =
     Missing(s"Could not find configuration at '${pathToString(path)}' and no default available").invalidNel[T]
+}
+
+object ResolutionCommon {
+  val TypeKey = "type"
 }

--- a/core/src/test/scala/extruder/core/ConfigSpec.scala
+++ b/core/src/test/scala/extruder/core/ConfigSpec.scala
@@ -5,7 +5,7 @@ import cats.syntax.either._
 import org.scalacheck.Gen.Choose
 import org.scalacheck.Shapeless._
 import org.scalacheck.{Gen, Prop}
-import org.specs2.matcher.EitherMatchers
+import org.specs2.matcher.{EitherMatchers, MatchResult}
 import org.specs2.specification.core.SpecStructure
 import org.specs2.{ScalaCheck, Specification}
 import org.typelevel.discipline.specs2.Discipline
@@ -41,9 +41,12 @@ trait ConfigSpec[C, I, J, D[T] <: Decoder[T, I], E[T] <: Encoder[T, J]] extends 
         FiniteDuration ${testType(finiteDurationGen)}
         Case class tree ${test(Gen.resultOf(CaseClass))}
         Case class with defaults set $testDefaults
-        $ext
 
-        ${checkAll("Encoder monoid", monoidGroupLaws.monoid(monoid))}
+      Can represent the following types as a table of required params
+        Case class tree $testCaseClassParams
+      $ext
+
+      ${checkAll("Encoder monoid", monoidGroupLaws.monoid(monoid))}
       """
 
   def testNumeric[T: Numeric](implicit encoder: E[T],
@@ -89,4 +92,6 @@ trait ConfigSpec[C, I, J, D[T] <: Decoder[T, I], E[T] <: Encoder[T, J]] extends 
     )
 
   def convertConfig(map: Map[String, String]): C
+
+  def testCaseClassParams: MatchResult[String] = parameters[CaseClass] !== ""
 }

--- a/core/src/test/scala/extruder/core/ParametersSpec.scala
+++ b/core/src/test/scala/extruder/core/ParametersSpec.scala
@@ -1,0 +1,107 @@
+package extruder.core
+
+import cats.data.NonEmptyList
+import org.specs2.matcher.MatchResult
+import org.specs2.specification.core.SpecStructure
+import org.specs2.{ScalaCheck, Specification}
+
+class ParametersSpec extends Specification with ScalaCheck {
+  import ParametersSpec._
+
+  override def is: SpecStructure =
+    s2"""
+       Can represent a
+        simple case class $simpleTest
+        case class with defaults $defaultTest
+        case class with an optional parameter $optionalTest
+        sealed family of types $sealedTest
+        case class with a case class parameter $nestedTest
+        case class with an optional case class parameter $nestedOptionTest
+        case class with traversable parameters $traversablesTest
+      """
+
+  def simpleTest: MatchResult[Any] = test[Simple](
+    List(List("Simple", "string"), List("Simple", "int")),
+    List(None, None),
+    List(true, true),
+    List("String", "Int")
+  )
+
+  def defaultTest: MatchResult[Any] = test[WithDefault](
+    List(List("WithDefault", "default")),
+    List(Some(default)),
+    List(false),
+    List("String")
+  )
+
+  def optionalTest: MatchResult[Any] = test[OptionalParam](
+    List(List("OptionalParam", "opt")),
+    List(None),
+    List(false),
+    List("String")
+  )
+
+  def sealedTest: MatchResult[Any] = test[Sealed](
+    List(List("type"), List("CCImpl", "d")),
+    List(None, None),
+    List(true, true),
+    List("Double"),
+    List(NonEmptyList.of("CCImpl", "ObjImpl"))
+  )
+
+  def nestedTest: MatchResult[Any] = test[Nested](
+    List(List("Nested", "cc", "Simple", "string"), List("Nested", "cc", "Simple", "int")),
+    List(None, None),
+    List(true, true),
+    List("String", "Int")
+  )
+
+  def nestedOptionTest: MatchResult[Any] = test[NestedOpt](
+    List(List("NestedOpt", "cc", "Simple", "string"), List("NestedOpt", "cc", "Simple", "int")),
+    List(None, None),
+    List(false, false),
+    List("String", "Int")
+  )
+
+  def traversablesTest: MatchResult[Any] = test[Traversables](
+    List(List("Traversables", "list"), List("Traversables", "opt")),
+    List(Some("one, two"), Some("1, 2")),
+    List(false, false),
+    List("List[String]", "List[Int]")
+  )
+
+  def test[T](expectedNames: List[List[String]],
+              expectedDefaults: List[Option[String]],
+              expectedRequired: List[Boolean],
+              expectedTypes: List[String] = List.empty,
+              expectedUnionTypes: List[NonEmptyList[String]] = List.empty)
+             (implicit params: Parameters[T]): MatchResult[Any] = {
+    val repr = params.eval(Seq.empty)
+    (repr.map(_.path) === expectedNames) and
+    (repr.map(_.default) === expectedDefaults) and
+    (repr.map(_.required) === expectedRequired) and
+    (repr.flatMap {
+      case x: StableRepr => Some(x.`type`)
+      case _: Any => None
+    } === expectedTypes) and
+    (repr.flatMap {
+      case x: UnionRepr => Some(x.types)
+      case _: Any => None
+    } === expectedUnionTypes)
+  }
+}
+
+object ParametersSpec {
+  case class Simple(string: String, int: Int)
+
+  val default: String = "default"
+  case class WithDefault(default: String = default)
+
+  case class OptionalParam(opt: Option[String])
+
+  case class Nested(cc: Simple)
+
+  case class NestedOpt(cc: Option[Simple])
+
+  case class Traversables(list: List[String] = List("one", "two"), opt: Option[List[Int]] = Some(List(1, 2)))
+}

--- a/examples/src/main/scala/extruder/examples/Grafter.scala
+++ b/examples/src/main/scala/extruder/examples/Grafter.scala
@@ -5,7 +5,7 @@ import cats.data.{NonEmptyList, Reader}
 import extruder.core.{ValidationError, ValidationException}
 import org.zalando.grafter.GenericReader._
 import org.zalando.grafter._
-import extruder.core.SystemPropertiesConfig._
+import extruder.system.SystemPropertiesConfig._
 
 case class ApplicationConfig(http: HttpConfig, db: DbConfig)
 

--- a/examples/src/main/scala/extruder/examples/Simple.scala
+++ b/examples/src/main/scala/extruder/examples/Simple.scala
@@ -4,7 +4,7 @@ import java.net.URL
 
 import cats.syntax.either._
 import cats.syntax.validated._
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.{ConfigFactory, ConfigObject}
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.numeric._
 import extruder.core._
@@ -13,19 +13,25 @@ import extruder.typesafe.TypesafeConfig
 import scala.collection.JavaConverters._
 import scala.concurrent.duration.{Duration, FiniteDuration}
 import extruder.refined._
+import extruder.system.{EnvironmentConfig, SystemPropertiesConfig}
 
 case class CC(a: String = "test", b: String = "test2", c: Int, d: Option[CC2], e: CC3, f: Set[Int], dur: Duration, finDur: FiniteDuration)
 case class CC2(x: String = "test4", y: Option[Int] = Some(232), z: CC3)
 case class CC3(a: Option[String])
 case class CC4(a: Option[CC3])
 
-case class Testing( s: Option[Long], d: Set[String], i: Int = 1)
+
+case class Testing(s: Option[Long], d: Set[String], i: Int = 1)
 
 sealed trait Sealed
 case object ObjImpl extends Sealed
-case class CCImpl(a: String, i: Long, u: URL, s: Set[Int], cc: CC4) extends Sealed
+case class CCImpl2(a: String) extends Sealed
+case class CCImpl(a: String, i: Long = 76, u: URL, s: Set[Int], cc: Option[CC4]) extends Sealed
 
-case class Hello(s: Sealed)
+case class Testing2(a: Set[Int] = Set(1,2), df: Option[Long] = Some(32L), dsf: Option[List[String]] = Some(List("dfs", "sdfsdf")))
+case class Testing3(b: String, c: Testing2)
+
+case class Hello(s: ConfigObject = ConfigFactory.parseMap(Map("sdfsdf" -> "dsfsdf").asJava).root())
 
 trait Thing[T] {
   def t: T
@@ -66,6 +72,11 @@ object Simple extends App {
   println(MapConfig.decode[Int Refined Positive](Map("" -> "23")).map(MapConfig.encode[Int Refined Positive]))
 
   println(EnvironmentConfig.decode[String](Seq("home")))
+
+
+  println(MapConfig.parameters[Sealed])
+  
+  println(EnvironmentConfig.parameters[Sealed])
 }
 
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 logLevel := Level.Warn
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")
-addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -84,7 +84,7 @@
  </check>
  <check level="warning" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="true">
   <parameters>
-   <parameter name="regex"><![CDATA[^[a-z][A-Za-z0-9]*$]]></parameter>
+   <parameter name="regex"><![CDATA[^[`a-z][A-Za-z0-9`]*$]]></parameter>
   </parameters>
  </check>
  <check level="warning" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" enabled="true">

--- a/system-sources/src/main/scala/extruder/system/EnvironmentConfig.scala
+++ b/system-sources/src/main/scala/extruder/system/EnvironmentConfig.scala
@@ -1,6 +1,7 @@
-package extruder.core
+package extruder.system
 
 import cats.syntax.validated._
+import extruder.core._
 
 import scala.collection.JavaConverters._
 

--- a/system-sources/src/main/scala/extruder/system/SystemPropertiesConfig.scala
+++ b/system-sources/src/main/scala/extruder/system/SystemPropertiesConfig.scala
@@ -1,7 +1,8 @@
-package extruder.core
+package extruder.system
 
 import cats.syntax.either._
 import cats.syntax.validated._
+import extruder.core._
 
 import scala.collection.JavaConverters._
 


### PR DESCRIPTION
- implements #4
- designed only to work on case classes and sealed families
- more types other than primitives can be added by including more `Show` instances
- add formatter which can take an implicit `Parameters` instance with a namespace and a path formatter, and output a table of all configuration options
- decoder instances now include a `parameters` method which optionally takes a namespace and outputs a table of parameters
- moved system properties and environment config sources to their own library (which is includeded in the base lib)