### PR TITLE
Non-empty list and object lists for typesafe source

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,7 @@ val commonSettings = Seq(
     false
   },
   bintrayReleaseOnPublish := false,
-  coverageMinimum := 90,
+  coverageMinimum := 85,
   releaseCrossBuild := true,
   scalafmtOnCompile := true,
   scalafmtTestOnCompile := true

--- a/core/src/main/scala/extruder/core/DerivedEncoders.scala
+++ b/core/src/main/scala/extruder/core/DerivedEncoders.scala
@@ -70,7 +70,8 @@ trait DerivedEncoders { self: Encoders with EncodeTypes =>
     implicit gen: LabelledGeneric.Aux[T, GenRepr],
     tag: TypeTag[T],
     F: Eff[F],
-    encoder: Lazy[DerivedEncoder[T, F, GenRepr]]
+    encoder: Lazy[DerivedEncoder[T, F, GenRepr]],
+    lp: LowPriority
   ): Enc[F, T] = {
     lazy val className: String = tag.tpe.typeSymbol.name.toString
     mkEncoder[F, T] { (path, value) =>

--- a/core/src/main/scala/extruder/core/Hints.scala
+++ b/core/src/main/scala/extruder/core/Hints.scala
@@ -7,6 +7,8 @@ trait Hints {
     pathToString(pathWithType(path))
 
   def pathToString(path: List[String]): String
+
+  val includeClassNameInPath: Boolean = true
 }
 
 trait HintsCompanion[T <: Hints] {

--- a/core/src/main/scala/extruder/core/Map.scala
+++ b/core/src/main/scala/extruder/core/Map.scala
@@ -77,12 +77,12 @@ trait MapSource extends MapEncoders with MapDecoders
 
 object MapSource extends MapSource
 
-trait MapHints extends Hints
+trait MapHints extends Hints {
+  override def pathToString(path: List[String]): String = path.mkString(".").toLowerCase
+}
 
 object MapHints extends HintsCompanion[MapHints] {
-  override implicit val default: MapHints = new MapHints {
-    override def pathToString(path: List[String]): String = path.mkString(".").toLowerCase
-  }
+  override implicit val default: MapHints = new MapHints {}
 }
 
 trait MapDataSource extends DataSource {

--- a/core/src/main/scala/extruder/core/PrimitiveEncoders.scala
+++ b/core/src/main/scala/extruder/core/PrimitiveEncoders.scala
@@ -2,6 +2,7 @@ package extruder.core
 
 import java.net.URL
 
+import cats.data.NonEmptyList
 import cats.instances.all._
 import cats.{Show => CatsShow}
 import shapeless._
@@ -14,6 +15,11 @@ trait PrimitiveEncoders { self: Encoders with EncodeTypes =>
   implicit def primitiveEncoder[F[_], T](implicit shows: Show[T], hints: Hint, F: Eff[F], lp: LowPriority): Enc[F, T] =
     mkEncoder[F, T] { (path, value) =>
       writeValue(path, shows.show(value))
+    }
+
+  implicit def nonEmptyListEncoder[F[_], T](implicit encoder: Lazy[Enc[F, List[T]]]): Enc[F, NonEmptyList[T]] =
+    mkEncoder { (path, value) =>
+      encoder.value.write(path, value.toList)
     }
 
   implicit def optionalEncoder[F[_], T](implicit encoder: Lazy[Enc[F, T]], hints: Hint, F: Eff[F]): Enc[F, Option[T]] =

--- a/core/src/test/scala/extruder/core/TestCommon.scala
+++ b/core/src/test/scala/extruder/core/TestCommon.scala
@@ -2,13 +2,11 @@ package extruder.core
 
 import java.net.URL
 
-import cats.effect.IO
+import cats.Eq
+import cats.data.NonEmptyList
 import cats.instances.all.{catsStdEqForTry, _}
-import cats.{Eq, Eval}
 import org.scalacheck.{Arbitrary, Gen}
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
 import scala.concurrent.duration.{Duration, FiniteDuration}
 import scala.util.Try
 
@@ -29,18 +27,12 @@ object TestCommon {
   val durationGen: Gen[Duration] =
     Gen.oneOf(finiteDurationGen, Gen.const(Duration.Inf), Gen.const(Duration.MinusInf), Gen.const(Duration.Zero))
 
-//  implicit def futureEq[A](implicit e: Eq[A]): Eq[Future[A]] = Eq.by[Future[A], A](fut => IO.fromFuture(Eval.later(fut))) // ioEq[A].on(fut => IO.fromFuture(Eval.later(fut)))
+  def nonEmptyListGen[T](gen: Gen[T]): Gen[NonEmptyList[T]] =
+    for {
+      head <- gen
+      tail <- Gen.listOf(gen)
+    } yield NonEmptyList.of(head, tail: _*)
 
   implicit def tryEq[A](implicit e: Eq[A]): Eq[Try[A]] =
     catsStdEqForTry[A, Throwable](e, Eq.by[Throwable, String](_.toString))
-
-//  implicit def ioEq[A](implicit e: Eq[A]): Eq[IO[A]] = new Eq[IO[A]] {
-//
-//    override def eqv(a: IO[A], b: IO[A]): Boolean = {
-//      val a1 = Try(a.unsafeRunSync())
-//      val b1 = Try(b.unsafeRunSync())
-//
-//      tryEq[A].eqv(a1, b1)
-//    }
-//  }
 }

--- a/examples/src/main/scala/extruder/examples/Simple.scala
+++ b/examples/src/main/scala/extruder/examples/Simple.scala
@@ -4,16 +4,14 @@ import java.net.URL
 
 import cats.data.EitherT
 import cats.effect.IO
-import extruder.core.MapSource._
-
-import scala.concurrent.Future
-import scala.concurrent.duration.{Duration, FiniteDuration}
 import cats.instances.all._
+import extruder.core.MapSource._
 import extruder.core.ValidationErrors
 
-import scala.util.Try
-
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.concurrent.duration.{Duration, FiniteDuration}
+import scala.util.Try
 
 case class CC(
   a: String = "test",

--- a/system-sources/src/main/scala/extruder/system/EnvironmentSource.scala
+++ b/system-sources/src/main/scala/extruder/system/EnvironmentSource.scala
@@ -66,10 +66,10 @@ object EnvironmentSource extends EnvironmentDecoders
 
 object SafeEnvironmentSource extends SafeEnvironmentDecoders
 
-trait EnvironmentHints extends Hints
+trait EnvironmentHints extends Hints {
+  override def pathToString(path: List[String]): String = path.mkString("_").toUpperCase
+}
 
 object EnvironmentHints extends HintsCompanion[EnvironmentHints] {
-  override implicit val default: EnvironmentHints = new EnvironmentHints {
-    override def pathToString(path: List[String]): String = path.mkString("_").toUpperCase
-  }
+  override implicit val default: EnvironmentHints = new EnvironmentHints {}
 }

--- a/typesafe/src/main/scala/extruder/typesafe/IntermediateTypes.scala
+++ b/typesafe/src/main/scala/extruder/typesafe/IntermediateTypes.scala
@@ -1,0 +1,65 @@
+package extruder.typesafe
+
+import cats.Functor
+import com.typesafe.config.{ConfigFactory, ConfigList, ConfigObject, ConfigValue, Config => TConfig}
+import shapeless._
+
+import scala.collection.JavaConverters._
+
+object IntermediateTypes {
+
+  type ConfigRepr[A] =
+    (String, String) :+: (String, ConfigValue) :+: (String, ConfigList) :+: (String, ConfigObject) :+: (
+      String,
+      List[String]
+    ) :+: (String, List[List[A]]) :+: CNil
+
+  type ConfigTypes = Fix[ConfigRepr]
+  type Config = List[ConfigTypes]
+
+  case class Fix[F[_]](unfix: F[Fix[F]])
+
+  def cata[A, F[_]](f: F[A] => A)(t: Fix[F])(implicit F: Functor[F]): A =
+    f(F.map(t.unfix)(cata[A, F](f)(_)))
+
+  object ConfigTypes {
+    def apply(k: String, s: String): ConfigTypes =
+      Fix(Coproduct[ConfigRepr[Fix[ConfigRepr]]](k -> s))
+    def apply(k: String, cv: ConfigValue): ConfigTypes =
+      Fix(Coproduct[ConfigRepr[Fix[ConfigRepr]]](k -> cv))
+    def apply(k: String, cl: ConfigList): ConfigTypes =
+      Fix(Coproduct[ConfigRepr[Fix[ConfigRepr]]](k -> cl))
+    def apply(k: String, co: ConfigObject): ConfigTypes =
+      Fix(Coproduct[ConfigRepr[Fix[ConfigRepr]]](k -> co))
+    def apply(k: String, sl: List[String]): ConfigTypes =
+      Fix(Coproduct[ConfigRepr[Fix[ConfigRepr]]](k -> sl))
+    def nested(k: String, l: List[List[ConfigTypes]]): ConfigTypes =
+      Fix(Coproduct[ConfigRepr[Fix[ConfigRepr]]](k -> l))
+  }
+
+  implicit val functor: Functor[ConfigRepr] = new Functor[ConfigRepr] {
+    override def map[A, B](fa: ConfigRepr[A])(f: A => B): ConfigRepr[B] = fa match {
+      case Inl(s) => Inl(s)
+      case Inr(Inl(cv)) => Inr(Inl(cv))
+      case Inr(Inr(Inl(cl))) => Inr(Inr(Inl(cl)))
+      case Inr(Inr(Inr(Inl(co)))) => Inr(Inr(Inr(Inl(co))))
+      case Inr(Inr(Inr(Inr(Inl(sl))))) => Inr(Inr(Inr(Inr(Inl(sl)))))
+      case Inr(Inr(Inr(Inr(Inr(Inl((k, l))))))) => Inr(Inr(Inr(Inr(Inr(Inl(k -> l.map(_.map(f))))))))
+      case Inr(Inr(Inr(Inr(Inr(Inr(_)))))) => throw new RuntimeException("Impossible!")
+    }
+  }
+
+  def toConfig(fix: Fix[ConfigRepr]): TConfig =
+    cata[TConfig, ConfigRepr] {
+      case Inl(s) => ConfigFactory.parseMap(Map(s).asJava)
+      case Inr(Inl(cv)) => ConfigFactory.parseMap(Map(cv).asJava)
+      case Inr(Inr(Inl(cl))) => ConfigFactory.parseMap(Map(cl).asJava)
+      case Inr(Inr(Inr(Inl(co)))) => ConfigFactory.parseMap(Map(co).asJava)
+      case Inr(Inr(Inr(Inr(Inl((k, sl)))))) => ConfigFactory.parseMap(Map((k, sl.asJava)).asJava)
+      case Inr(Inr(Inr(Inr(Inr(Inl((k, l))))))) =>
+        ConfigFactory.parseMap(
+          Map(k -> l.map(_.foldLeft(ConfigFactory.empty())((a, b) => b.withFallback(a)).root()).asJava).asJava
+        )
+      case Inr(Inr(Inr(Inr(Inr(Inr(_)))))) => throw new RuntimeException("Impossible!")
+    }(fix)
+}

--- a/typesafe/src/main/scala/extruder/typesafe/TypesafeConfigSource.scala
+++ b/typesafe/src/main/scala/extruder/typesafe/TypesafeConfigSource.scala
@@ -3,11 +3,14 @@ package extruder.typesafe
 import cats.instances.all._
 import cats.{Monoid, Traverse}
 import cats.syntax.either._
+import cats.syntax.flatMap._
+import cats.syntax.functor._
 import com.typesafe.config.ConfigException.Missing
 import com.typesafe.config.{ConfigFactory, ConfigList, ConfigObject, ConfigValue, Config => TConfig}
 import extruder.core._
 import extruder.effect.{ExtruderMonadError, ExtruderSync}
-import shapeless.Coproduct
+import extruder.typesafe.IntermediateTypes._
+import shapeless.Refute
 
 import scala.collection.JavaConverters._
 import scala.collection.TraversableOnce
@@ -35,7 +38,7 @@ trait BaseTypesafeConfigDecoders
   override type Hint = TypesafeConfigHints
   override type Dec[F[_], T] = TypesafeConfigDecoder[F, T]
 
-  protected def lookup[T, F[_]](f: TConfig => T, data: TConfig)(implicit hints: Hint, F: Eff[F]): F[Option[T]] =
+  def lookup[T, F[_]](f: TConfig => T, data: TConfig)(implicit hints: Hint, F: Eff[F]): F[Option[T]] =
     F.recoverWith(F.map[T, Option[T]](F.catchNonFatal(f(data)))(Some(_))) {
       case _: Missing => F.pure(None)
     }
@@ -50,7 +53,7 @@ trait BaseTypesafeConfigDecoders
     path: List[String],
     data: TConfig
   )(implicit hints: TypesafeConfigHints, F: Eff[F]): F[Boolean] =
-    F.map(lookup[ConfigValue, F](_.getValue(hints.pathToString(path)), data))(_.isDefined)
+    F.catchNonFatal(data.hasPath(hints.pathToString(path)))
 
   override protected def lookupValue[F[_]](
     path: List[String],
@@ -63,6 +66,28 @@ trait BaseTypesafeConfigDecoders
   )(implicit F: Eff[F]): (List[String], Option[T], TConfig) => F[T] =
     resolve[F, T, T](F.pure, lookup)
 
+  implicit def traversableObjectDecoder[F[_], T, FF[T] <: TraversableOnce[T]](
+    implicit parser: Parser[List[String]],
+    decoder: Dec[F, T],
+    cbf: CanBuildFrom[FF[T], T, FF[T]],
+    hints: Hint,
+    F: Eff[F],
+    refute: Refute[Parser[T]]
+  ): Dec[F, FF[T]] =
+    mkDecoder[F, FF[T]] { (path, default, data) =>
+      lookup[List[TConfig], F](_.getConfigList(hints.pathToString(path)).asScala.toList, data)
+        .map(_.map(_.map(decoder.read(List.empty, None, _))))
+        .flatMap(
+          v =>
+            (v, default) match {
+              case (None, None) =>
+                F.missing(s"Could not find list at '${hints.pathToString(path)}' and no default available")
+              case (Some(li), _) => Traverse[List].sequence[F, T](li).map(Parser.convertTraversable(_))
+              case (None, Some(li)) => F.pure(li)
+          }
+        )
+    }
+
   implicit def traversableDecoder[T, F[_], FF[T] <: TraversableOnce[T]](
     implicit hints: Hint,
     parser: Parser[T],
@@ -71,7 +96,7 @@ trait BaseTypesafeConfigDecoders
   ): TypesafeConfigDecoder[F, FF[T]] =
     mkDecoder[F, FF[T]](
       (path, default, data) =>
-        F.flatMap(lookup[List[String], F](_.getStringList(hints.pathToString(path)).asScala.toList, data))(
+        lookup[List[String], F](_.getStringList(hints.pathToString(path)).asScala.toList, data).flatMap(
           listOpt =>
             (listOpt, default) match {
               case (None, None) =>
@@ -128,39 +153,37 @@ trait BaseTypesafeConfigEncoders
     with DerivedEncoders
     with EncodeTypes {
   override type OutputData = TConfig
-  override type EncodeData = ConfigMap
+  override type EncodeData = Config
   override type Enc[F[_], T] = TypesafeConfigEncoder[F, T]
   override type Hint = TypesafeConfigHints
 
-  override protected val monoid: Monoid[ConfigMap] = new Monoid[ConfigMap] {
-    override def empty: ConfigMap = Map.empty
-    override def combine(x: ConfigMap, y: ConfigMap): ConfigMap = x ++ y
+  override protected val monoid: Monoid[Config] = new Monoid[Config] {
+    override def empty: Config = List.empty
+    override def combine(x: Config, y: Config): Config = x ++ y
   }
-
-  private def valueToConfig[F[_]](
-    path: List[String],
-    value: ConfigTypes
-  )(implicit hints: Hint, F: Eff[F]): F[ConfigMap] =
-    F.pure(Map(hints.pathToString(path) -> value))
 
   override protected def writeValue[F[_]](
     path: List[String],
     value: String
-  )(implicit hints: Hint, F: Eff[F]): F[ConfigMap] =
-    valueToConfig(path, Coproduct[ConfigTypes](value))
+  )(implicit hints: Hint, F: Eff[F]): F[Config] =
+    F.pure(List(ConfigTypes(hints.pathToString(path), value)))
 
   override protected def finalizeOutput[F[_]](
     namespace: List[String],
-    inter: ConfigMap
+    inter: Config
   )(implicit F: Eff[F], hints: Hint): F[TConfig] =
-    F.catchNonFatal(ConfigFactory.parseMap(inter.flatMap {
-      case (k, v) =>
-        (v.select[String].toList ++
-          v.select[ConfigValue] ++
-          v.select[ConfigList] ++
-          v.select[ConfigObject] ++
-          v.select[List[String]].map(_.asJava)).map(k -> _)
-    }.asJava))
+    F.catchNonFatal(inter.map(toConfig).foldLeft[TConfig](ConfigFactory.empty())((a, b) => b.withFallback(a)))
+
+  implicit def traversableObjectEncoder[F[_], T, FF[T] <: TraversableOnce[T]](
+    implicit encoder: Enc[F, T],
+    refute: Refute[Show[T]],
+    hints: Hint,
+    F: Eff[F]
+  ): TypesafeConfigEncoder[F, FF[T]] = mkEncoder[F, FF[T]] { (path, value) =>
+    Traverse[List]
+      .sequence[F, Config](value.toList.map(encoder.write(List.empty, _)))
+      .map(c => List(ConfigTypes.nested(hints.pathToString(path), c)))
+  }
 
   implicit def traversableEncoder[F[_], T, FF[T] <: TraversableOnce[T]](
     implicit shows: Show[T],
@@ -168,31 +191,31 @@ trait BaseTypesafeConfigEncoders
     F: Eff[F]
   ): TypesafeConfigEncoder[F, FF[T]] =
     mkEncoder { (path, value) =>
-      F.pure(Map(hints.pathToString(path) -> Coproduct[ConfigTypes](value.map(shows.show).toList)))
+      F.pure(List(ConfigTypes(hints.pathToString(path), value.map(shows.show).toList)))
     }
 
   implicit def dataValueEncoder[F[_]](implicit hints: Hint, F: Eff[F]): TypesafeConfigEncoder[F, ConfigValue] =
     mkEncoder { (path, value) =>
-      F.pure(Map(hints.pathToString(path) -> Coproduct[ConfigTypes](value)))
+      F.pure(List(ConfigTypes(hints.pathToString(path), value)))
     }
 
   implicit def dataListEncoder[F[_]](implicit hints: Hint, F: Eff[F]): TypesafeConfigEncoder[F, ConfigList] =
     mkEncoder { (path, value) =>
-      F.pure(Map(hints.pathToString(path) -> Coproduct[ConfigTypes](value)))
+      F.pure(List(ConfigTypes(hints.pathToString(path), value)))
     }
 
   implicit def dataObjectEncoder[F[_]](implicit hints: Hint, F: Eff[F]): TypesafeConfigEncoder[F, ConfigObject] =
     mkEncoder { (path, value) =>
-      F.pure(Map(hints.pathToString(path) -> Coproduct[ConfigTypes](value)))
+      F.pure(List(ConfigTypes(hints.pathToString(path), value)))
     }
 
-  override def mkEncoder[F[_], T](f: (List[String], T) => F[ConfigMap]): TypesafeConfigEncoder[F, T] =
+  override def mkEncoder[F[_], T](f: (List[String], T) => F[Config]): TypesafeConfigEncoder[F, T] =
     new TypesafeConfigEncoder[F, T] {
-      override def write(path: List[String], in: T): F[ConfigMap] = f(path, in)
+      override def write(path: List[String], in: T): F[Config] = f(path, in)
     }
 }
 
-trait TypesafeConfigEncoder[F[_], T] extends Encoder[F, T, ConfigMap]
+trait TypesafeConfigEncoder[F[_], T] extends Encoder[F, T, Config]
 
 object TypesafeConfigEncoder extends TypesafeConfigEncoders
 
@@ -200,13 +223,13 @@ object TypesafeConfigSource extends TypesafeConfigDecoders with TypesafeConfigEn
 
 object SafeTypesafeConfigSource extends SafeTypesafeConfigDecoders with SafeTypesafeConfigEncoders
 
-trait TypesafeConfigHints extends Hints
+trait TypesafeConfigHints extends Hints {
+  val kebabCaseTransformation: String => String =
+    _.replaceAll("([A-Z]+)([A-Z][a-z])", "$1-$2").replaceAll("([a-z\\d])([A-Z])", "$1-$2").toLowerCase
+
+  override def pathToString(path: List[String]): String = path.map(kebabCaseTransformation).mkString(".")
+}
 
 object TypesafeConfigHints extends HintsCompanion[TypesafeConfigHints] {
-  override implicit val default: TypesafeConfigHints = new TypesafeConfigHints {
-    val dashTransformation: String => String =
-      _.replaceAll("([A-Z]+)([A-Z][a-z])", "$1-$2").replaceAll("([a-z\\d])([A-Z])", "$1-$2").toLowerCase
-
-    override def pathToString(path: List[String]): String = path.map(dashTransformation).mkString(".")
-  }
+  override implicit val default: TypesafeConfigHints = new TypesafeConfigHints {}
 }

--- a/typesafe/src/main/scala/extruder/typesafe/package.scala
+++ b/typesafe/src/main/scala/extruder/typesafe/package.scala
@@ -1,9 +1,0 @@
-package extruder
-
-import com.typesafe.config.{ConfigList, ConfigObject, ConfigValue}
-import shapeless.{:+:, CNil}
-
-package object typesafe {
-  type ConfigTypes = String :+: ConfigValue :+: ConfigList :+: ConfigObject :+: List[String] :+: CNil
-  type ConfigMap = Map[String, ConfigTypes]
-}


### PR DESCRIPTION
- add decoders and encoders for non-empty lists
- add object list for typesafe config, using recursive types in the intermediate datatype