### PR TITLE
Add metrics encoders

### DIFF
--- a/core/src/main/scala/extruder/core/Decoders.scala
+++ b/core/src/main/scala/extruder/core/Decoders.scala
@@ -169,7 +169,10 @@ trait Decoder[F[_], T, C] {
   def read(path: List[String], default: Option[T], input: C): F[T]
 }
 
+trait DecoderRefute[T]
+
 trait DecodeTypes extends DataSource {
   type DecodeData
   type Dec[F[_], T] <: Decoder[F, T, DecodeData]
+  type DecRefute[T] <: DecoderRefute[T]
 }

--- a/core/src/main/scala/extruder/core/DerivedDecoders.scala
+++ b/core/src/main/scala/extruder/core/DerivedDecoders.scala
@@ -38,6 +38,7 @@ trait DerivedDecoders { self: Decoders with DecodeTypes =>
     underlying: Lazy[Dec[F, V]],
     F: Eff[F],
     lp: LowPriority,
+    refute: Refute[DecoderRefute[T]],
     refuteParser: Refute[Parser[T]],
     refuteMultiParser: Refute[MultiParser[T]],
     neOpt: T <:!< Option[_],
@@ -85,6 +86,7 @@ trait DerivedDecoders { self: Decoders with DecodeTypes =>
     decoder: Lazy[DerivedDecoderWithDefault[T, F, GenRepr, DefaultOptsRepr]],
     hints: Hint,
     lp: LowPriority,
+    refute: Refute[DecRefute[T]],
     refuteParser: Refute[Parser[T]],
     refuteMultiParser: Refute[MultiParser[T]]
   ): Dec[F, T] =

--- a/core/src/main/scala/extruder/core/DerivedEncoders.scala
+++ b/core/src/main/scala/extruder/core/DerivedEncoders.scala
@@ -35,6 +35,7 @@ trait DerivedEncoders { self: Encoders with EncodeTypes =>
     underlying: Lazy[Enc[F, O]],
     F: Eff[F],
     lp: LowPriority,
+    refute: Refute[EncoderRefute[T]],
     refuteShow: Refute[Show[T]],
     refuteMultiShow: Refute[MultiShow[T]],
     neOpt: T <:!< Option[_],
@@ -74,6 +75,7 @@ trait DerivedEncoders { self: Encoders with EncodeTypes =>
     F: Eff[F],
     encoder: Lazy[DerivedEncoder[T, F, GenRepr]],
     lp: LowPriority,
+    refute: Refute[EncRefute[T]],
     refuteShow: Refute[Show[T]],
     refuteMultiShow: Refute[MultiShow[T]]
   ): Enc[F, T] = {

--- a/core/src/main/scala/extruder/core/Encoders.scala
+++ b/core/src/main/scala/extruder/core/Encoders.scala
@@ -85,7 +85,10 @@ trait Encoder[F[_], T, O] {
   def write(path: List[String], in: T): F[O]
 }
 
+trait EncoderRefute[T]
+
 trait EncodeTypes extends DataSource {
   type EncodeData
   type Enc[F[_], T] <: Encoder[F, T, EncodeData]
+  type EncRefute[T] <: EncoderRefute[T]
 }

--- a/docs/src/main/resources/microsite/data/menu.yml
+++ b/docs/src/main/resources/microsite/data/menu.yml
@@ -9,3 +9,5 @@ options:
     url: extending.html
   - title: Implementing a Data Source
     url: config.html
+  - title: Extruder Metrics
+    url: metrics.html

--- a/docs/src/main/tut/metrics.md
+++ b/docs/src/main/tut/metrics.md
@@ -1,0 +1,160 @@
+---
+layout: docs
+title:  "Metrics"
+position: 6
+---
+* TOC
+{:toc}
+
+# Overview
+The extruder metrics modules provide support for encoding case classes as name-spaced or dimensional metrics.
+
+# Metric Encoding
+
+Exturder supports two types of metric encoding schemes, name-spaced and dimensional. Both are described below:
+
+## Name-spaced Metrics
+Name-spaced metrics are most commonly associated with [Graphite](https://graphiteapp.org/), where they are simple key values arranged in a hierarchy of common dot-seprated key elements.
+
+Metrics are encoded using the path to the value in the case class structure e.g.
+
+```scala
+case class Test1(value: Int = 1000)
+case class Test2(metrics: Test1)
+```
+Will be encoded as `test2.metrics.test1.value = 1000`.
+
+## Dimensional metrics
+Dimensional metrics are most commonly associated with [Prometheus](https://prometheus.io/) where a metric has multiple labels which then may be queried in aggregate with other metrics which share the same dimensions.
+
+Metrics in a case class can be encoded as follows, providing there is enough depth in the case class structure to be able to create dimensions:
+
+```scala
+case class StatusCode(`200`: Int = 2043, `500`: Int = 3, other: Int = 653)
+case class RequestCount(httpRequests: StatusCode)
+```
+
+Will be encoded as:
+```
+{name=http_requests,status_code=200} = 2043
+{name=http_requests,status_code=500} = 3
+{name=http_requests,status_code=other} = 653
+```
+This allows you to aggregate all `http_requests` values by not including the `status_code` dimension in a query.
+
+
+Alternatively if there is not enough depth in the case class structure then names will be encoded as the parameter names of the case class:
+
+```scala
+case class HttpResponses(`200Responses`: Int = 2043, `500Responses`: Int = 3, otherResponses: Int = 653)
+```
+
+Will be encoded as:
+```
+{name=200_responses,status_code=200} = 2043
+{name=500_responses,status_code=500} = 3
+{name=other_responses,status_code=other} = 653
+```
+
+If you don't know the possible label values ahead of time it is possible to encode a map of string to number which represents each dimension value and its corresponding reading:
+
+```scala
+case class HttpRequests(statusCode: Map[String, Int] = Map("200" -> 2043, "500" -> 3, "401" -> 7643, "other" -> 12))
+```
+
+Will be encoded as:
+
+```
+{name=http_requests,status_code=200} = 2043
+{name=http_requests,status_code=500} = 3
+{name=http_requests,status_code=400} = 7643
+{name=http_requests,status_code=other} = 12
+```
+
+## Lack of depth
+
+If your case class heirarchy is not deep enough, then extruder will encode the case class's field names as metrics. For example:
+
+```scala
+case class StatusCode(`200`: Int = 2043, `500`: Int = 3, other: Int = 653)
+```
+
+Will be encoded as:
+```
+{name=200} = 2043
+{name=500} = 3
+{name=other} = 653
+```
+
+## Additional dimensions
+
+When instantiating an implementation of a dimensional metric encoder you may provide optional additional dimensions as a string map (`Map[String, String]`). This allows you to specify extra metadata such as hostname or job instance to every metric recorded.
+
+### Encoding and compilation
+
+Note that dimensional metric encoders will fail to compile case classes which cannot be properly represented as dimensional metrics, i.e. any case class whose fields would be encoded as separate labels would not compile if those fields are not all the same type.
+
+# Metric Types
+
+In order to encode a type of metric extruder includes a trait called `MetricValue`. Provided implementations include `Counter`, `Gauge` and `Timer`, each being a [value class](https://docs.scala-lang.org/overviews/core/value-classes.html). A case class which uses these allows for fine grained control over the type of metric for each value.
+
+To encode multiple dimensions in a `Map`, as covered above, the type `MetricValues` is provided, which is a [value class](https://docs.scala-lang.org/overviews/core/value-classes.html) class wrapper around `Map[String, MetricValue[V]]` where `V` has an implicit `Numeric` instance. An implicit monoid instance is also providied for this type.
+
+For example it is possible to 
+
+```tut:silent
+import extruder.metrics.data.CounterValue
+import extruder.metrics.conversions.counter._ //implicitly converts numbers to CounterValue
+
+case class StatusCode(`200`: CounterValue[Int] = 2043, `500`: CounterValue[Int] = 3, other: CounterValue[Int] = 653)
+case class RequestCount(httpRequests: StatusCode)
+```
+
+If you don't wish to use `MetricValue` or `MetricValues` in your case classes, encoding will still work (as seen above), however the values will be encoded as the default metric type for the encoder.
+
+# Label Values
+
+Any type which cannot be encoded as a numeric value can be encoded as a label where the value of the field will be included in the name of the metric and the metric value set to `1`. For example, consider the following case class:
+
+```scala
+case class Stats(status: String = "OK")
+```
+
+Will be encoded as below in name-spaced metrics:
+```
+stats.status.OK = 1
+```
+Or in dimensional metrics:
+```
+{status=OK} = 1
+```
+# Provided Encoders
+
+Extruder currently provides three types of encoders, although anyone is welcome to add more:
+
+## Dropwizard
+
+The [Dropwizard](http://metrics.dropwizard.io) package provides name-spaced metric encoder which records values in a Dropwizard metrics registry.
+
+```scala
+resolvers += Resolver.bintrayRepo("janstenpickle", "maven")
+libraryDependencies += "extruder" %% "extruder-dropwizard" % "0.7.6"
+```
+
+## Prometheus
+
+The [Prometheus](https://prometheus.io/) package provides two dimensional metric encoders, one which records values in a Prometheus metrics registry and one which sends metrics to a [Push Gateway](https://github.com/prometheus/pushgateway).
+
+```scala
+resolvers += Resolver.bintrayRepo("janstenpickle", "maven")
+libraryDependencies += "extruder" %% "extruder-prometheus" % "0.7.6"
+```
+
+## Spectator
+
+The [Spectator](https://github.com/Netflix/spectator) package provides a dimensional metric encode which records in a Spectator metrics registry.
+
+```scala
+resolvers += Resolver.bintrayRepo("janstenpickle", "maven")
+libraryDependencies += "extruder" %% "extruder-spectator" % "0.7.6"
+```

--- a/metrics/core/src/main/scala/extruder/metrics/MetricEncoders.scala
+++ b/metrics/core/src/main/scala/extruder/metrics/MetricEncoders.scala
@@ -1,0 +1,96 @@
+package extruder.metrics
+
+import cats.instances.list._
+import cats.syntax.applicative._
+import cats.syntax.functor._
+import cats.{Monoid, Traverse}
+import extruder.core._
+import extruder.metrics.data._
+import extruder.metrics.syntax.timer._
+import shapeless.ops.coproduct.Inject
+import shapeless.{Coproduct, Refute}
+
+import scala.concurrent.duration.FiniteDuration
+
+trait MetricEncoders
+    extends PrimitiveEncoders
+    with StringMapEncoders
+    with DerivedEncoders
+    with Encoders
+    with EncodeTypes {
+  override type EncodeData = Metrics
+
+  override protected def monoid: Monoid[EncodeData] = new Monoid[EncodeData] {
+    override def empty: EncodeData = Map.empty
+    override def combine(x: EncodeData, y: EncodeData): EncodeData =
+      y.foldLeft(x) {
+        case (acc, (k, v)) => acc + (k -> acc.get(k).fold(v)(Numbers.add(_, v)))
+      }
+  }
+
+  override protected def writeValue[F[_]](
+    path: List[String],
+    value: String
+  )(implicit hints: Hint, F: Eff[F]): F[EncodeData] =
+    F.pure(Metrics.status(path, value))
+
+  implicit def traversableThrowableEncoder[F[_]: Eff, FF[A] <: TraversableOnce[A]]: Enc[F, FF[Throwable]] = mkEncoder {
+    (path, values) =>
+      Metrics.single(MetricKey(path, Some(MetricType.Gauge)), Coproduct[Numbers](values.size)).pure[F]
+  }
+
+  implicit def traversableEncoder[F[_]: Eff, T, FF[A] <: TraversableOnce[A]](
+    implicit encoder: Enc[F, T]
+  ): Enc[F, FF[T]] =
+    mkEncoder[F, FF[T]] { (path, values) =>
+      Traverse[List].traverse(values.toList)(encoder.write(path, _)).map(monoid.combineAll)
+    }
+
+  implicit def numericMapEncoder[F[_]: Eff, T](implicit inj: Inject[Numbers, T]): Enc[F, Map[String, T]] =
+    mkEncoder[F, Map[String, T]] { (path, values) =>
+      monoid
+        .combineAll(values.map {
+          case (k, v) => Metrics.single(MetricKey(path :+ k, None), Coproduct[Numbers](v))
+        })
+        .pure[F]
+    }
+
+  implicit def metricValuesEncoder[F[_]: Eff, T, V[A] <: MetricValue[A]](
+    implicit inj: Inject[Numbers, T]
+  ): Enc[F, MetricValues[V, T]] =
+    mkEncoder[F, MetricValues[V, T]] { (path, mv) =>
+      monoid
+        .combineAll(mv.values.map {
+          case (k, v) => Metrics.single(MetricKey(path :+ k, Some(v.metricType)), Coproduct[Numbers](v.value))
+        })
+        .pure[F]
+    }
+
+  implicit def numericEncoder[F[_]: Eff, T](implicit inj: Inject[Numbers, T]): Enc[F, T] = mkEncoder[F, T] {
+    (path, value) =>
+      Metrics.single(MetricKey(path, None), Coproduct[Numbers](value)).pure[F]
+  }
+
+  implicit def metricValueEncoder[F[_]: Eff, T, V[A] <: MetricValue[A]](
+    implicit inj: Inject[Numbers, T],
+    refute: Refute[Enc[F, V[T]]]
+  ): Enc[F, V[T]] = mkEncoder[F, V[T]] { (path, mv) =>
+    Metrics.single(MetricKey(path, Some(mv.metricType)), Coproduct[Numbers](mv.value)).pure[F]
+  }
+
+  implicit def timerEncoder[F[_]: Eff]: Enc[F, TimerValue[Long]] = mkEncoder[F, TimerValue[Long]] { (path, tv) =>
+    val v = if (tv.isFinished) tv else tv.checkpoint()
+    Metrics.single(MetricKey(path, Some(MetricType.Timer)), Coproduct[Numbers](v.value)).pure[F]
+  }
+
+  implicit def durationEncoder[F[_]: Eff]: Enc[F, FiniteDuration] = mkEncoder { (path, dur) =>
+    Metrics.single(MetricKey(path, Some(MetricType.Timer)), Coproduct[Numbers](dur.toMillis)).pure[F]
+  }
+
+}
+
+trait MetricEncoder[F[_], T] extends Encoder[F, T, Metrics]
+
+trait MetricsHints extends Hints {
+  override def pathToString(path: List[String]): String = path.map(snakeCaseTransformation).mkString(".")
+}

--- a/metrics/core/src/main/scala/extruder/metrics/conversions/AllConversions.scala
+++ b/metrics/core/src/main/scala/extruder/metrics/conversions/AllConversions.scala
@@ -1,0 +1,3 @@
+package extruder.metrics.conversions
+
+trait AllConversions extends CounterConversions with GaugeConversions with TimerConversions

--- a/metrics/core/src/main/scala/extruder/metrics/conversions/CounterConversions.scala
+++ b/metrics/core/src/main/scala/extruder/metrics/conversions/CounterConversions.scala
@@ -1,0 +1,7 @@
+package extruder.metrics.conversions
+
+import extruder.metrics.data.CounterValue
+
+trait CounterConversions {
+  implicit def numericToCounter[A: Numeric](a: A): CounterValue[A] = CounterValue(a)
+}

--- a/metrics/core/src/main/scala/extruder/metrics/conversions/GaugeConversions.scala
+++ b/metrics/core/src/main/scala/extruder/metrics/conversions/GaugeConversions.scala
@@ -1,0 +1,7 @@
+package extruder.metrics.conversions
+
+import extruder.metrics.data.GaugeValue
+
+trait GaugeConversions {
+  implicit def numericToGauge[A: Numeric](a: A): GaugeValue[A] = GaugeValue(a)
+}

--- a/metrics/core/src/main/scala/extruder/metrics/conversions/TimerConversions.scala
+++ b/metrics/core/src/main/scala/extruder/metrics/conversions/TimerConversions.scala
@@ -1,0 +1,8 @@
+package extruder.metrics.conversions
+
+import extruder.metrics.data.TimerValue
+
+trait TimerConversions {
+  implicit def longToTimer(l: Long): TimerValue[Long] = TimerValue(l)
+  implicit def tupleToTimer(ll: (Long, Long)): TimerValue[Long] = TimerValue(ll._1, Some(ll._2))
+}

--- a/metrics/core/src/main/scala/extruder/metrics/conversions/package.scala
+++ b/metrics/core/src/main/scala/extruder/metrics/conversions/package.scala
@@ -1,0 +1,8 @@
+package extruder.metrics
+
+package object conversions {
+  object all extends AllConversions
+  object counter extends CounterConversions
+  object gauge extends GaugeConversions
+  object timer extends TimerConversions
+}

--- a/metrics/core/src/main/scala/extruder/metrics/data/MetricKey.scala
+++ b/metrics/core/src/main/scala/extruder/metrics/data/MetricKey.scala
@@ -1,0 +1,3 @@
+package extruder.metrics.data
+
+case class MetricKey(name: List[String], metricType: Option[MetricType])

--- a/metrics/core/src/main/scala/extruder/metrics/data/MetricType.scala
+++ b/metrics/core/src/main/scala/extruder/metrics/data/MetricType.scala
@@ -1,0 +1,20 @@
+package extruder.metrics.data
+
+trait MetricType {
+  def name: String
+}
+
+object MetricType {
+  case object Counter extends MetricType {
+    override def name: String = "counter"
+  }
+  case object Gauge extends MetricType {
+    override def name: String = "gauge"
+  }
+  case object Status extends MetricType {
+    override def name: String = "status"
+  }
+  case object Timer extends MetricType {
+    override def name: String = "timer"
+  }
+}

--- a/metrics/core/src/main/scala/extruder/metrics/data/MetricValue.scala
+++ b/metrics/core/src/main/scala/extruder/metrics/data/MetricValue.scala
@@ -1,0 +1,60 @@
+package extruder.metrics.data
+
+import cats.Monoid
+import extruder.metrics.data.MetricType.{Counter, Gauge, Timer}
+
+import scala.math.Numeric.Implicits._
+
+trait MetricValue[T] extends Any {
+  def value: T
+  def metricType: MetricType
+}
+
+case class GaugeValue[T](value: T) extends AnyVal with MetricValue[T] {
+  override def metricType: MetricType = Gauge
+  def +(rhs: GaugeValue[T])(implicit num: Numeric[T]): GaugeValue[T] = GaugeValue(value + rhs.value)
+}
+
+object GaugeValue {
+  implicit def monoid[A](implicit num: Numeric[A]): Monoid[GaugeValue[A]] = new Monoid[GaugeValue[A]] {
+    override def empty: GaugeValue[A] = GaugeValue(num.zero)
+    override def combine(x: GaugeValue[A], y: GaugeValue[A]): GaugeValue[A] = x + y
+  }
+}
+
+case class CounterValue[T](value: T) extends AnyVal with MetricValue[T] {
+  override def metricType: MetricType = Counter
+  def +(rhs: CounterValue[T])(implicit num: Numeric[T]): CounterValue[T] = CounterValue(value + rhs.value)
+}
+
+object CounterValue {
+  implicit def monoid[A](implicit num: Numeric[A]): Monoid[CounterValue[A]] = new Monoid[CounterValue[A]] {
+    override def empty: CounterValue[A] = CounterValue(num.zero)
+    override def combine(x: CounterValue[A], y: CounterValue[A]): CounterValue[A] = x + y
+  }
+}
+
+case class TimerValue[T](start: T, finish: Option[T] = None)(implicit num: Numeric[T]) extends MetricValue[T] {
+  override lazy val value: T = finish.fold(num.zero)(_ - start)
+  override val metricType: MetricType = Timer
+
+  def checkpoint(time: T): TimerValue[T] = copy(finish = Some(time))
+  def isFinished: Boolean = finish.isDefined
+}
+
+object TimerValue {
+  def apply(): TimerValue[Long] = TimerValue(System.currentTimeMillis())
+
+  // Note this is not a lawful monoid as the empty value is the current time
+  implicit val monoid: Monoid[TimerValue[Long]] = new Monoid[TimerValue[Long]] {
+    override def empty: TimerValue[Long] = TimerValue(System.currentTimeMillis())
+
+    override def combine(x: TimerValue[Long], y: TimerValue[Long]): TimerValue[Long] = {
+      val finish =
+        if (x.isFinished || y.isFinished) Some(math.max(x.finish.getOrElse(0L), y.finish.getOrElse(0L)))
+        else None
+
+      TimerValue(math.min(x.start, y.start), finish)
+    }
+  }
+}

--- a/metrics/core/src/main/scala/extruder/metrics/data/MetricValues.scala
+++ b/metrics/core/src/main/scala/extruder/metrics/data/MetricValues.scala
@@ -1,0 +1,20 @@
+package extruder.metrics.data
+
+import cats.Monoid
+import cats.syntax.monoid._
+
+case class MetricValues[T[A] <: MetricValue[A], V](values: Map[String, T[V]]) extends AnyVal {
+  def +(elem: (String, T[V]))(implicit num: Numeric[V], V: Monoid[T[V]]): MetricValues[T, V] = {
+    val (k, v) = elem
+    MetricValues(values + (k -> (v |+| values.getOrElse(k, V.empty))))
+  }
+}
+
+object MetricValues {
+  implicit def monoid[A[T] <: MetricValue[T], B: Numeric](implicit B: Monoid[A[B]]): Monoid[MetricValues[A, B]] =
+    new Monoid[MetricValues[A, B]] {
+      override def empty: MetricValues[A, B] = MetricValues[A, B](Map.empty)
+      override def combine(x: MetricValues[A, B], y: MetricValues[A, B]): MetricValues[A, B] =
+        y.values.foldLeft(x)(_ + _)
+    }
+}

--- a/metrics/core/src/main/scala/extruder/metrics/data/Metrics.scala
+++ b/metrics/core/src/main/scala/extruder/metrics/data/Metrics.scala
@@ -1,0 +1,11 @@
+package extruder.metrics.data
+
+import shapeless.Coproduct
+
+object Metrics {
+  def single(key: MetricKey, value: Numbers): Metrics = Map(key -> value)
+  def status(key: List[String], value: String): Metrics = {
+    val s: Short = 1
+    Map(MetricKey(key :+ value, Some(MetricType.Status)) -> Coproduct[Numbers](s))
+  }
+}

--- a/metrics/core/src/main/scala/extruder/metrics/data/Numbers.scala
+++ b/metrics/core/src/main/scala/extruder/metrics/data/Numbers.scala
@@ -1,0 +1,32 @@
+package extruder.metrics.data
+
+import shapeless.{Coproduct, Inl, Inr}
+
+object Numbers {
+  def add(l: Numbers, r: Numbers): Numbers = (l, r) match {
+    case (Inl(n1), Inl(n2)) => Coproduct[Numbers](n1 + n2)
+    case (Inr(Inl(n1)), Inr(Inl(n2))) => Coproduct[Numbers](n1 + n2)
+    case (Inr(Inr(Inl(n1))), Inr(Inr(Inl(n2)))) => Coproduct[Numbers](n1 + n2)
+    case (Inr(Inr(Inr(Inl(n1)))), Inr(Inr(Inr(Inl(n2))))) => Coproduct[Numbers](n1 + n2)
+    case (Inr(Inr(Inr(Inr(Inl(n1))))), Inr(Inr(Inr(Inr(Inl(n2)))))) => Coproduct[Numbers](n1 + n2)
+    case (n1, n2) => Coproduct[Numbers](toDouble(n1) + toDouble(n2))
+  }
+
+  def to[A](
+    fromShort: Short => A,
+    fromInt: Int => A,
+    fromLong: Long => A,
+    fromFloat: Float => A,
+    fromDouble: Double => A
+  ): Numbers => A = {
+    case Inl(s) => fromShort(s)
+    case Inr(Inl(i)) => fromInt(i)
+    case Inr(Inr(Inl(l))) => fromLong(l)
+    case Inr(Inr(Inr(Inl(f)))) => fromFloat(f)
+    case Inr(Inr(Inr(Inr(Inl(d))))) => fromDouble(d)
+    case Inr(Inr(Inr(Inr(Inr(_))))) => throw new RuntimeException("Impossible!")
+  }
+
+  val toDouble: Numbers => Double = to[Double](_.toDouble, _.toDouble, _.toDouble, _.toDouble, identity)
+  val toLong: Numbers => Long = to[Long](_.toLong, _.toLong, identity, _.toLong, _.toLong)
+}

--- a/metrics/core/src/main/scala/extruder/metrics/data/package.scala
+++ b/metrics/core/src/main/scala/extruder/metrics/data/package.scala
@@ -1,0 +1,12 @@
+package extruder.metrics
+
+import shapeless.{:+:, CNil}
+
+package object data {
+  type CounterValues[A] = MetricValues[CounterValue, A]
+  type GaugeValues[A] = MetricValues[GaugeValue, A]
+  type TimerValues = MetricValues[TimerValue, Long]
+
+  type Numbers = Short :+: Int :+: Long :+: Float :+: Double :+: CNil
+  type Metrics = Map[MetricKey, Numbers]
+}

--- a/metrics/core/src/main/scala/extruder/metrics/dimensional/DimensionalMetricEncoders.scala
+++ b/metrics/core/src/main/scala/extruder/metrics/dimensional/DimensionalMetricEncoders.scala
@@ -1,0 +1,193 @@
+package extruder.metrics.dimensional
+
+import cats.data.NonEmptyList
+import extruder.core.{EncoderRefute, Show}
+import extruder.metrics.MetricEncoders
+import extruder.metrics.data._
+import shapeless.ops.hlist.{Length, Mapper, Repeat, Take}
+import shapeless.{<:!<, =:!=, Generic, HList, Nat, Poly1, Refute}
+
+import scala.concurrent.duration.FiniteDuration
+
+trait DimensionalMetricEncoders extends MetricEncoders {
+  val metricTypeName = "metric_type"
+
+  override type EncRefute[T] = DimensionalMetricEncoderRefute[T]
+
+  def labelTransform(value: String): String
+
+  implicit def resetNamespaceEncoder[F[_]: Eff, T](implicit enc: Enc[F, T]): Enc[F, ResetNamespace[T]] =
+    mkEncoder[F, ResetNamespace[T]] { (path, v) =>
+      enc.write(path.lastOption.fold(path)(List(_)), v.value)
+    }
+
+  protected def buildMetrics[F[_]](
+    namespaceName: Option[String],
+    namespace: List[String],
+    inter: Metrics,
+    defaultLabels: Map[String, String],
+    defaultMetricType: MetricType
+  )(implicit F: Eff[F], hints: Hint): F[Iterable[DimensionalMetric]] = {
+    val defaultDimensionNames = defaultLabels.keySet ++ namespaceName + metricTypeName
+    val defaultDimensionValues = defaultLabels.values.toVector
+
+    val metrics =
+      inter.flatMap { case (k, v) => calculateDimensions(namespace, defaultMetricType)(k, v) }.groupBy(_.key).map {
+        case ((name, metricType, labelName), ms) =>
+          val dimensions: Set[String] = defaultDimensionNames ++ labelName
+
+          val values = ms.foldLeft(Map.empty[Vector[String], Numbers]) {
+            case (acc, metric) =>
+              val dimensionValues = (defaultDimensionValues ++ namespaceName
+                .map(_ => metric.namespace.getOrElse("")) :+ metricType.name) ++ metric.labelVal
+
+              acc + (dimensionValues -> acc.get(dimensionValues).fold(metric.value)(Numbers.add(_, metric.value)))
+          }
+
+          DimensionalMetric(name, dimensions, metricType, values)
+      }
+
+    val metricTypes = metrics
+      .foldLeft(Map.empty[String, Set[MetricType]]) { (acc, m) =>
+        acc + (m.name -> (acc.getOrElse(m.name, Set.empty) + m.metricType))
+      }
+      .filter(_._2.size != 1)
+
+    if (metricTypes.isEmpty) F.pure(metrics)
+    else {
+      val invalid = metricTypes.map { case (name, types) => s"'$name' -> '${types.mkString(", ")}'" }.mkString(", ")
+      F.validationFailure(s"Multiple metric types for the following metrics, please ensure there is just one: $invalid")
+    }
+  }
+
+  private def calculateDimensions(namespace: List[String], defaultMetricType: MetricType)(key: MetricKey, v: Numbers)(
+    implicit hints: Hint
+  ): Option[Metric] =
+    (key.metricType.getOrElse(defaultMetricType) match {
+      case MetricType.Status => calculateStatusDimensions(namespace) _
+      case _ => calculateMetricDimensions(namespace, defaultMetricType) _
+    })(key, v)
+
+  private def calculateStatusDimensions(
+    namespace: List[String]
+  )(key: MetricKey, v: Numbers)(implicit hints: Hint): Option[Metric] =
+    (namespace ++ key.name).reverse match {
+      case name :: nameTail =>
+        Some(SimpleMetric(labelTransform(name), calculateNameSpace(nameTail), MetricType.Status, v))
+      case _ => None
+    }
+
+  private def calculateMetricDimensions(
+    namespace: List[String],
+    defaultMetricType: MetricType
+  )(key: MetricKey, v: Numbers)(implicit hints: Hint): Option[Metric] =
+    (namespace ++ key.name).reverse match {
+      case labelValue :: labelName :: name :: nameTail =>
+        Some(
+          LabelledMetric(
+            labelTransform(name),
+            calculateNameSpace(nameTail),
+            labelTransform(labelName),
+            labelValue,
+            key.metricType.getOrElse(defaultMetricType),
+            v
+          )
+        )
+      case name :: nameTail =>
+        Some(
+          SimpleMetric(
+            labelTransform(name),
+            calculateNameSpace(nameTail),
+            key.metricType.getOrElse(defaultMetricType),
+            v
+          )
+        )
+      case _ => None
+    }
+
+  private def calculateNameSpace(nameTail: List[String])(implicit hints: Hint): Option[String] =
+    NonEmptyList.fromList(nameTail).map(nel => hints.pathToString(nel.toList))
+
+}
+
+trait DimensionalMetricEncoderRefute[T] extends EncoderRefute[T]
+
+object DimensionalMetricEncoderRefute {
+  implicit def refute[T, Repr <: HList](
+    implicit gen: Generic.Aux[T, Repr],
+    unRefute: Refute[UnRefute[T]]
+  ): DimensionalMetricEncoderRefute[T] =
+    new DimensionalMetricEncoderRefute[T] {}
+}
+
+trait UnRefute[T] {}
+
+object UnRefute {
+  implicit def unRefuteGeneric[T, Repr <: HList](
+    implicit gen: Generic.Aux[T, Repr],
+    mapper: Mapper[genericElements.type, Repr],
+    refuteLen: Refute[Length.Aux[Repr, Nat._1]]
+  ): UnRefute[T] = new UnRefute[T] {}
+
+  object genericElements extends Poly1 {
+    implicit def caseGeneric[A](
+      implicit gen: Generic[A],
+      ev: A <:!< MetricValue[_],
+      ev1: A <:!< ResetNamespace[_],
+      ev2: A =:!= FiniteDuration
+    ): Case.Aux[A, Unit] = at[A](_ => ())
+
+    implicit def caseNonNumericShow[A](
+      implicit show: Show[A],
+      refute: Refute[Numeric[A]],
+      ev: A =:!= FiniteDuration
+    ): Case.Aux[A, Unit] =
+      at[A](_ => ())
+  }
+
+  implicit def unRefuteIdentical[A, Repr <: HList, Len <: Nat, Taken <: HList, Rep <: HList](
+    implicit gen: Generic.Aux[A, Repr],
+    len: Length.Aux[Repr, Len],
+    take: Take.Aux[Repr, Nat._1, Taken],
+    rep: Repeat.Aux[Taken, Len, Rep],
+    ev: Rep =:= Repr
+  ): UnRefute[A] = new UnRefute[A] {}
+
+  implicit def unRefuteMetricValue[A](implicit ev: A <:< MetricValue[_]): UnRefute[A] = new UnRefute[A] {}
+}
+
+sealed trait Metric {
+  def name: String
+  def metricType: MetricType
+  def value: Numbers
+  def namespace: Option[String]
+  def labelPair: Option[(String, String)]
+  def labelVal: Option[String] = labelPair.map(_._2)
+
+  def key: (String, MetricType, Option[String]) = (name, metricType, labelPair.map(_._1))
+}
+case class LabelledMetric private[dimensional] (
+  name: String,
+  namespace: Option[String],
+  labelName: String,
+  labelValue: String,
+  metricType: MetricType,
+  value: Numbers
+) extends Metric {
+  override def labelPair: Option[(String, String)] = Some(labelName -> labelValue)
+}
+case class SimpleMetric private[dimensional] (
+  name: String,
+  namespace: Option[String],
+  metricType: MetricType,
+  value: Numbers
+) extends Metric {
+  override def labelPair: Option[(String, String)] = None
+}
+
+case class DimensionalMetric private[dimensional] (
+  name: String,
+  labelNames: Set[String],
+  metricType: MetricType,
+  values: Map[Vector[String], Numbers]
+)

--- a/metrics/core/src/main/scala/extruder/metrics/dimensional/ResetNamespace.scala
+++ b/metrics/core/src/main/scala/extruder/metrics/dimensional/ResetNamespace.scala
@@ -1,0 +1,14 @@
+package extruder.metrics.dimensional
+
+import cats.kernel.Monoid
+
+case class ResetNamespace[T](value: T) extends AnyVal
+
+object ResetNamespace {
+  implicit def monoid[A](implicit A: Monoid[A]): Monoid[ResetNamespace[A]] = new Monoid[ResetNamespace[A]] {
+    override def empty: ResetNamespace[A] = ResetNamespace[A](A.empty)
+
+    override def combine(x: ResetNamespace[A], y: ResetNamespace[A]): ResetNamespace[A] =
+      ResetNamespace[A](A.combine(x.value, y.value))
+  }
+}

--- a/metrics/core/src/main/scala/extruder/metrics/keyed/KeyedMetricEncoders.scala
+++ b/metrics/core/src/main/scala/extruder/metrics/keyed/KeyedMetricEncoders.scala
@@ -1,0 +1,24 @@
+package extruder.metrics.keyed
+
+import extruder.metrics.MetricEncoders
+import extruder.metrics.data.{MetricType, Metrics, Numbers}
+
+trait KeyedMetricEncoders extends MetricEncoders {
+  protected def buildMetrics[F[_]](
+    inter: Metrics,
+    defaultMetricType: MetricType
+  )(implicit F: Eff[F], hints: Hint): F[Iterable[KeyedMetric]] =
+    F.pure(
+      inter
+        .foldLeft(Map.empty[(String, MetricType), Numbers]) {
+          case (acc, (k, v)) =>
+            val key = (hints.pathToString(k.name), k.metricType.getOrElse(defaultMetricType))
+
+            acc + (key -> acc.get(key).fold(v)(Numbers.add(v, _)))
+        }
+        .map { case ((k, t), v) => KeyedMetric(k, t, v) }
+        .toList
+    )
+}
+
+case class KeyedMetric private[keyed] (name: String, metricType: MetricType, value: Numbers)

--- a/metrics/core/src/main/scala/extruder/metrics/package.scala
+++ b/metrics/core/src/main/scala/extruder/metrics/package.scala
@@ -1,0 +1,6 @@
+package extruder
+
+package object metrics {
+  val snakeCaseTransformation: String => String =
+    _.replaceAll("([A-Z]+)([A-Z][a-z])", "$1_$2").replaceAll("([a-z\\d])([A-Z])", "$1_$2").toLowerCase
+}

--- a/metrics/core/src/main/scala/extruder/metrics/syntax/AllSyntax.scala
+++ b/metrics/core/src/main/scala/extruder/metrics/syntax/AllSyntax.scala
@@ -1,0 +1,3 @@
+package extruder.metrics.syntax
+
+trait AllSyntax extends CounterSyntax with GaugeSyntax with TimerSyntax

--- a/metrics/core/src/main/scala/extruder/metrics/syntax/CounterSyntax.scala
+++ b/metrics/core/src/main/scala/extruder/metrics/syntax/CounterSyntax.scala
@@ -1,0 +1,9 @@
+package extruder.metrics.syntax
+
+import extruder.metrics.data.CounterValue
+
+trait CounterSyntax {
+  implicit class NumericCounterOps[T: Numeric](t: T) {
+    def toCounter: CounterValue[T] = CounterValue(t)
+  }
+}

--- a/metrics/core/src/main/scala/extruder/metrics/syntax/GaugeSyntax.scala
+++ b/metrics/core/src/main/scala/extruder/metrics/syntax/GaugeSyntax.scala
@@ -1,0 +1,9 @@
+package extruder.metrics.syntax
+
+import extruder.metrics.data.GaugeValue
+
+trait GaugeSyntax {
+  implicit class NumericGaugeOps[T: Numeric](t: T) {
+    def toGauge: GaugeValue[T] = GaugeValue(t)
+  }
+}

--- a/metrics/core/src/main/scala/extruder/metrics/syntax/TimerSyntax.scala
+++ b/metrics/core/src/main/scala/extruder/metrics/syntax/TimerSyntax.scala
@@ -1,0 +1,24 @@
+package extruder.metrics.syntax
+
+import extruder.metrics.data.TimerValue
+
+import scala.concurrent.duration.FiniteDuration
+
+trait TimerSyntax {
+  implicit class LongOps(l: Long) {
+    def toTimer: TimerValue[Long] = TimerValue(l)
+    def toTimer(finish: Long): TimerValue[Long] = TimerValue(l, Some(finish))
+    def toTimer(finish: FiniteDuration): TimerValue[Long] = toTimer(finish.toMillis)
+  }
+
+  implicit class FiniteDurationOps(dur: FiniteDuration) {
+    private def millis = dur.toMillis
+    def toTimer: TimerValue[Long] = millis.toTimer
+    def toTimer(finish: Long): TimerValue[Long] = millis.toTimer(finish)
+    def toTimer(finish: FiniteDuration): TimerValue[Long] = millis.toTimer(finish)
+  }
+
+  implicit class LongTimerOps(timer: TimerValue[Long]) {
+    def checkpoint(): TimerValue[Long] = timer.checkpoint(System.currentTimeMillis())
+  }
+}

--- a/metrics/core/src/main/scala/extruder/metrics/syntax/package.scala
+++ b/metrics/core/src/main/scala/extruder/metrics/syntax/package.scala
@@ -1,0 +1,8 @@
+package extruder.metrics
+
+package object syntax {
+  object all extends AllSyntax
+  object counter extends CounterSyntax
+  object gauge extends GaugeSyntax
+  object timer extends TimerSyntax
+}

--- a/metrics/core/src/test/scala/extruder/metrics/MetricEncodersSpec.scala
+++ b/metrics/core/src/test/scala/extruder/metrics/MetricEncodersSpec.scala
@@ -1,0 +1,211 @@
+package extruder.metrics
+
+import java.util.concurrent.TimeUnit
+
+import cats.Eq
+import cats.instances.string._
+import cats.kernel.laws.discipline.MonoidTests
+import extruder.core.Validation
+import extruder.effect.ExtruderMonadError
+import extruder.metrics.data._
+import org.scalacheck.ScalacheckShapeless._
+import org.scalacheck.{Arbitrary, Gen, Prop}
+import org.specs2.matcher.{EitherMatchers, Matchers}
+import org.specs2.specification.core.SpecStructure
+import org.specs2.{ScalaCheck, Specification}
+import org.typelevel.discipline.specs2.Discipline
+import shapeless.Coproduct
+
+import scala.concurrent.duration.FiniteDuration
+
+class MetricEncodersSpec
+    extends Specification
+    with ScalaCheck
+    with Matchers
+    with EitherMatchers
+    with Discipline
+    with MetricEncoders {
+  import MetricEncodersSpec._
+
+  override type Enc[F[_], T] = TestMetricEncoder[F, T]
+  override type OutputData = Metrics
+  override type Eff[F[_]] = ExtruderMonadError[F]
+  override type Hint = TestMetricsHints.type
+
+  private implicit val ev = monoid
+
+  override def is: SpecStructure =
+    s2"""
+        Can encode an Int $testInt
+        Can encode a Long $testLong
+        Can encode a Double $testDouble
+        Can encode a Float $testFloat
+        Can encode a FiniteDuration $testFiniteDuration
+        Can encode a non-numeric value as a label $testNonNum
+
+        Can encode a Map $testMap
+        Can encode a numeric List $testNumList
+        Can encode a non-numeric List $testNonNumList
+        Can encode a List of Throwables $testThrowableList
+
+        Can encode metric value $testMetricValue
+        Can encode timer value $testTimer
+        Can encode values $testValues
+        Can encode metric values $testValues
+
+        Can encode an object $testObject
+        Can encode an object containing a values map $testObjectMap
+        Can encode Both types of object in the same object $testBoth
+
+        ${checkAll("Encoder monoid", MonoidTests[EncodeData].monoid)}
+      """
+
+  def testInt(implicit enc: TestMetricEncoder[Validation, Int]): Prop = prop { (i: Int, name: String) =>
+    enc.write(List(name), i) must beRight(Map(MetricKey(List(name), None) -> Coproduct[Numbers](i)))
+  }
+
+  def testLong(implicit enc: TestMetricEncoder[Validation, Long]): Prop = prop { (l: Long, name: String) =>
+    enc.write(List(name), l) must beRight(Map(MetricKey(List(name), None) -> Coproduct[Numbers](l)))
+  }
+
+  def testDouble(implicit enc: TestMetricEncoder[Validation, Double]): Prop = prop { (d: Double, name: String) =>
+    enc.write(List(name), d) must beRight(Map(MetricKey(List(name), None) -> Coproduct[Numbers](d)))
+  }
+
+  def testFloat(implicit enc: TestMetricEncoder[Validation, Float]): Prop = prop { (f: Float, name: String) =>
+    enc.write(List(name), f) must beRight(Map(MetricKey(List(name), None) -> Coproduct[Numbers](f)))
+  }
+
+  def testMap(implicit enc: TestMetricEncoder[Validation, Map[String, Int]]): Prop = prop { (map: Map[String, Int]) =>
+    enc.write(List.empty, map) must beRight(map.map {
+      case (k, v) => MetricKey(List(k), None) -> Coproduct[Numbers](v)
+    })
+  }
+
+  def testFiniteDuration(implicit enc: TestMetricEncoder[Validation, FiniteDuration]): Prop = prop {
+    (dur: FiniteDuration, name: String) =>
+      enc.write(List(name), dur) must beRight(
+        Map(MetricKey(List(name), Some(MetricType.Timer)) -> Coproduct[Numbers](dur.toMillis))
+      )
+  }
+
+  def testNonNum(implicit enc: TestMetricEncoder[Validation, String]): Prop = prop { (s: String, name: String) =>
+    val short: Short = 1
+    enc.write(List(name), s) must beRight(
+      Map(MetricKey(List(name, s), Some(MetricType.Status)) -> Coproduct[Numbers](short))
+    )
+  }
+
+  def testNumList(implicit enc: TestMetricEncoder[Validation, List[Int]]): Prop = prop {
+    (li: List[Int], name: String) =>
+      val key = MetricKey(List(name), None)
+
+      enc.write(List(name), li) must beRight(
+        li.foldLeft(Map.empty[MetricKey, Numbers])(
+          (acc, v) => acc + (key -> acc.get(key).fold(Coproduct[Numbers](v))(Numbers.add(_, Coproduct[Numbers](v))))
+        )
+      )
+  }
+
+  def testNonNumList(implicit enc: TestMetricEncoder[Validation, List[String]]): Prop = prop {
+    (li: List[String], name: String) =>
+      val short: Short = 1
+      enc.write(List(name), li) must beRight(li.foldLeft(Map.empty[MetricKey, Numbers]) { (acc, v) =>
+        val key = MetricKey(List(name, v), Some(MetricType.Status))
+        acc + (key -> acc.get(key).fold(Coproduct[Numbers](short))(Numbers.add(_, Coproduct[Numbers](short))))
+      })
+  }
+
+  def testThrowableList(implicit enc: TestMetricEncoder[Validation, List[Throwable]]): Prop = prop {
+    (li: List[Throwable], name: String) =>
+      enc.write(List(name), li) must beRight(
+        Map(MetricKey(List(name), Some(MetricType.Gauge)) -> Coproduct[Numbers](li.size))
+      )
+  }
+
+  def testMetricValue(implicit enc: TestMetricEncoder[Validation, MetricValue[Double]]): Prop = prop {
+    (mv: MetricValue[Double], name: String) =>
+      enc.write(List(name), mv) must beRight(
+        Map(MetricKey(List(name), Some(mv.metricType)) -> Coproduct[Numbers](mv.value))
+      )
+  }
+
+  def testTimer(implicit enc: TestMetricEncoder[Validation, TimerValue[Long]]): Prop = prop {
+    (start: Long, finish: Long, name: String) =>
+      enc.write(List(name), TimerValue(start, Some(finish))) must
+        beRight(Map(MetricKey(List(name), Some(MetricType.Timer)) -> Coproduct[Numbers](finish - start)))
+  }
+
+  def testValues(implicit enc: TestMetricEncoder[Validation, MetricValues[MetricValue, Double]]): Prop = prop {
+    (values: Map[String, Double]) =>
+      enc.write(List.empty, MetricValues(values.mapValues(GaugeValue[Double]))) must beRight(values.map {
+        case (k, v) => MetricKey(List(k), Some(MetricType.Gauge)) -> Coproduct[Numbers](v)
+      })
+  }
+
+  def testObject(implicit enc: TestMetricEncoder[Validation, RequestCount]): Prop = prop { (rq: RequestCount) =>
+    enc.write(List.empty, rq) must beRight(
+      Map(
+        MetricKey(requestCountPath :+ "200", None) -> Coproduct[Numbers](rq.httpRequests.`200`),
+        MetricKey(requestCountPath :+ "500", None) -> Coproduct[Numbers](rq.httpRequests.`500`),
+        MetricKey(requestCountPath :+ "other", None) -> Coproduct[Numbers](rq.httpRequests.other)
+      )
+    )
+  }
+
+  def testObjectMap(implicit enc: TestMetricEncoder[Validation, HttpRequests]): Prop = prop { (rq: HttpRequests) =>
+    enc.write(List.empty, rq) must beRight(rq.statusCode.values.map {
+      case (k, v) => MetricKey(httpRequestsPath :+ k, Some(MetricType.Counter)) -> Coproduct[Numbers](v.value)
+    })
+  }
+
+  def testBoth(implicit enc: TestMetricEncoder[Validation, Both]): Prop = prop { (rq: Both) =>
+    enc.write(List.empty, rq) must beRight(
+      Map(
+        MetricKey(List("Both", "a") ++ requestCountPath :+ "200", None) -> Coproduct[Numbers](rq.a.httpRequests.`200`),
+        MetricKey(List("Both", "a") ++ requestCountPath :+ "500", None) -> Coproduct[Numbers](rq.a.httpRequests.`500`),
+        MetricKey(List("Both", "a") ++ requestCountPath :+ "other", None) -> Coproduct[Numbers](rq.a.httpRequests.other)
+      ) ++ rq.b.statusCode.values.map {
+        case (k, v) =>
+          MetricKey(List("Both", "b") ++ httpRequestsPath :+ k, Some(MetricType.Counter)) -> Coproduct[Numbers](v.value)
+      }
+    )
+  }
+
+  override protected def mkEncoder[F[_], T](f: (List[String], T) => F[Metrics]): TestMetricEncoder[F, T] =
+    new TestMetricEncoder[F, T] {
+      override def write(path: List[String], in: T): F[Metrics] = f(path, in)
+    }
+}
+
+object MetricEncodersSpec {
+  val requestCountPath: List[String] = List("RequestCount", "httpRequests", "StatusCode")
+  case class StatusCode(`200`: Int, `500`: Int, other: Int)
+  case class RequestCount(httpRequests: StatusCode)
+
+  val httpRequestsPath: List[String] = List("HttpRequests", "statusCode")
+  case class HttpRequests(statusCode: CounterValues[Int])
+
+  case class Both(a: RequestCount, b: HttpRequests)
+
+  trait TestMetricEncoder[F[_], T] extends MetricEncoder[F, T]
+
+  object TestMetricsHints extends MetricsHints
+
+  implicit val hints: TestMetricsHints.type = TestMetricsHints
+
+  implicit def doubleMetricValueArb: Arbitrary[MetricValue[Double]] =
+    Arbitrary(for {
+      tpe <- Gen.oneOf(GaugeValue.apply[Double] _, CounterValue.apply[Double] _)
+      dbl <- implicitly[Arbitrary[Double]].arbitrary
+    } yield tpe(dbl))
+
+  implicit def durArb: Arbitrary[FiniteDuration] =
+    Arbitrary(Gen.posNum[Int].map(i => FiniteDuration(i.toLong, TimeUnit.MILLISECONDS)))
+
+  implicit val metricTypeArb: Arbitrary[MetricType] = Arbitrary(
+    Gen.oneOf(MetricType.Counter, MetricType.Gauge, MetricType.Status, MetricType.Timer)
+  )
+
+  implicit val metricsEq: Eq[Metrics] = Eq.by(_.mapValues(Numbers.toDouble).toString)
+}

--- a/metrics/core/src/test/scala/extruder/metrics/conversions/CounterConversionsSpec.scala
+++ b/metrics/core/src/test/scala/extruder/metrics/conversions/CounterConversionsSpec.scala
@@ -1,0 +1,20 @@
+package extruder.metrics.conversions
+
+import extruder.metrics.conversions.counter._
+import extruder.metrics.data.CounterValue
+import org.scalacheck.Prop
+import org.specs2.matcher.Matchers
+import org.specs2.specification.core.SpecStructure
+import org.specs2.{ScalaCheck, Specification}
+
+class CounterConversionsSpec extends Specification with ScalaCheck with Matchers {
+  override def is: SpecStructure =
+    s2"""
+        Can convert a numeric into a counter $testNumeric
+      """
+
+  def testNumeric: Prop = prop { (i: Int) =>
+    val c: CounterValue[Int] = i
+    c === CounterValue(i)
+  }
+}

--- a/metrics/core/src/test/scala/extruder/metrics/conversions/GaugeConversionsSpec.scala
+++ b/metrics/core/src/test/scala/extruder/metrics/conversions/GaugeConversionsSpec.scala
@@ -1,0 +1,20 @@
+package extruder.metrics.conversions
+
+import extruder.metrics.conversions.gauge._
+import extruder.metrics.data.GaugeValue
+import org.scalacheck.Prop
+import org.specs2.matcher.Matchers
+import org.specs2.specification.core.SpecStructure
+import org.specs2.{ScalaCheck, Specification}
+
+class GaugeConversionsSpec extends Specification with ScalaCheck with Matchers {
+  override def is: SpecStructure =
+    s2"""
+        Can convert a numeric into a gauge $testNumeric
+      """
+
+  def testNumeric: Prop = prop { (i: Int) =>
+    val c: GaugeValue[Int] = i
+    c === GaugeValue(i)
+  }
+}

--- a/metrics/core/src/test/scala/extruder/metrics/conversions/TimerConversionsSpec.scala
+++ b/metrics/core/src/test/scala/extruder/metrics/conversions/TimerConversionsSpec.scala
@@ -1,0 +1,26 @@
+package extruder.metrics.conversions
+
+import extruder.metrics.conversions.timer._
+import extruder.metrics.data.TimerValue
+import org.scalacheck.Prop
+import org.specs2.matcher.Matchers
+import org.specs2.specification.core.SpecStructure
+import org.specs2.{ScalaCheck, Specification}
+
+class TimerConversionsSpec extends Specification with ScalaCheck with Matchers {
+  override def is: SpecStructure =
+    s2"""
+        Can convert a long to a timer $testLong
+        Can convert a tuple of longs to a completed timer $testTuple
+      """
+
+  def testLong: Prop = prop { (l: Long) =>
+    val t: TimerValue[Long] = l
+    t === TimerValue(l)
+  }
+
+  def testTuple: Prop = prop { (ll: (Long, Long)) =>
+    val t: TimerValue[Long] = ll
+    t === TimerValue(ll._1, Some(ll._2))
+  }
+}

--- a/metrics/core/src/test/scala/extruder/metrics/data/MetricValueSpec.scala
+++ b/metrics/core/src/test/scala/extruder/metrics/data/MetricValueSpec.scala
@@ -1,0 +1,67 @@
+package extruder.metrics.data
+
+import cats.Eq
+import cats.instances.all._
+import cats.kernel.Monoid
+import cats.kernel.laws.discipline.MonoidTests
+import org.scalacheck.ScalacheckShapeless._
+import org.specs2.execute.Result
+import org.specs2.{ScalaCheck, Specification}
+import org.specs2.specification.core.SpecStructure
+import org.typelevel.discipline.specs2.Discipline
+
+class MetricValueSpec extends Specification with Discipline {
+  import MetricValueSpec._
+
+  override def is: SpecStructure =
+    s2"""
+      ${checkAll("Counter monoid", MonoidTests[CounterValue[Int]].monoid)}
+      ${checkAll("Gauge monoid", MonoidTests[GaugeValue[Int]].monoid)}
+
+      Can create a timer value with the start set to the current time $timerStart
+
+      Timer monoid
+        Can create a timer value with the start set to the current time $timerMonoidEmpty
+        Combines two unfinished timers, setting the start to lowest value $timerMonoidNotFinished
+        Combines two timers where one is finished $timerMonoidOneFinished
+        Combines two timers where both are finished $timerMonoidBothFinished
+      """
+
+  def timerStart: Result = {
+    val min = System.currentTimeMillis()
+    val timerStart = TimerValue().start
+    (timerStart >= min).and(timerStart <= System.currentTimeMillis())
+  }
+
+  def timerMonoidEmpty: Result = {
+    val min = System.currentTimeMillis()
+    val timerStart = Monoid[TimerValue[Long]].empty.start
+    (timerStart >= min).and(timerStart <= System.currentTimeMillis())
+  }
+
+  def timerMonoidNotFinished: Result = {
+    val first = TimerValue()
+    val second = TimerValue()
+    Monoid[TimerValue[Long]].combine(first, second).start === first.start
+  }
+
+  def timerMonoidOneFinished: Result = {
+    val first = TimerValue()
+    val second = TimerValue().checkpoint(System.currentTimeMillis())
+    val combined = Monoid[TimerValue[Long]].combine(first, second)
+    (combined.start === first.start).and(combined.finish === second.finish)
+  }
+
+  def timerMonoidBothFinished: Result = {
+    val first = TimerValue()
+    val second = TimerValue().checkpoint(System.currentTimeMillis())
+    val third = first.checkpoint(System.currentTimeMillis())
+    val combined = Monoid[TimerValue[Long]].combine(first, second)
+    (combined.start === third.start).and(combined.finish === third.finish)
+  }
+}
+
+object MetricValueSpec {
+  implicit def counterEq[A: Eq]: Eq[CounterValue[A]] = Eq.by(_.value)
+  implicit def gaugeEq[A: Eq]: Eq[GaugeValue[A]] = Eq.by(_.value)
+}

--- a/metrics/core/src/test/scala/extruder/metrics/data/MetricValuesSpec.scala
+++ b/metrics/core/src/test/scala/extruder/metrics/data/MetricValuesSpec.scala
@@ -1,0 +1,20 @@
+package extruder.metrics.data
+
+import cats.Eq
+import cats.instances.all._
+import cats.kernel.laws.discipline.MonoidTests
+import org.scalacheck.ScalacheckShapeless._
+import org.specs2.Specification
+import org.specs2.specification.core.SpecStructure
+import org.typelevel.discipline.specs2.Discipline
+
+class MetricValuesSpec extends Specification with Discipline {
+  import MetricValuesSpec._
+
+  override def is: SpecStructure =
+    checkAll("Metric values monoid", MonoidTests[MetricValues[CounterValue, Int]].monoid)
+}
+
+object MetricValuesSpec {
+  implicit val metricValuesEq: Eq[MetricValues[CounterValue, Int]] = Eq.by(_.toString)
+}

--- a/metrics/core/src/test/scala/extruder/metrics/dimensional/DimensionalMetricEncodersSpec.scala
+++ b/metrics/core/src/test/scala/extruder/metrics/dimensional/DimensionalMetricEncodersSpec.scala
@@ -1,0 +1,171 @@
+package extruder.metrics.dimensional
+
+import cats.data.NonEmptyList
+import cats.syntax.either._
+import extruder.core.{Encode, Validation, ValidationFailure}
+import extruder.effect.ExtruderMonadError
+import extruder.metrics.MetricEncodersSpec.{RequestCount, StatusCode}
+import extruder.metrics._
+import extruder.metrics.data._
+import org.scalacheck.Prop
+import org.scalacheck.ScalacheckShapeless._
+import org.specs2.matcher.{EitherMatchers, MatchResult, Matchers}
+import org.specs2.specification.core.SpecStructure
+import org.specs2.{ScalaCheck, Specification}
+import shapeless.Coproduct
+import utest.compileError
+
+class DimensionalMetricEncodersSpec
+    extends Specification
+    with ScalaCheck
+    with Matchers
+    with EitherMatchers
+    with DimensionalMetricEncoders
+    with Encode {
+  import DimensionalMetricEncodersSpec._
+  import extruder.metrics.MetricEncodersSpec._
+
+  override type Enc[F[_], T] = TestMetricEncoder[F, T]
+  override type OutputData = Iterable[DimensionalMetric]
+  override type Eff[F[_]] = ExtruderMonadError[F]
+  override type Hint = TestMetricsHints.type
+
+  override protected def mkEncoder[F[_], T](f: (List[String], T) => F[Metrics]): TestMetricEncoder[F, T] =
+    new TestMetricEncoder[F, T] {
+      override def write(path: List[String], in: T): F[Metrics] = f(path, in)
+    }
+
+  override protected def finalizeOutput[F[_]](namespace: List[String], inter: Metrics)(
+    implicit F: ExtruderMonadError[F],
+    hints: TestMetricsHints.type
+  ): F[Iterable[DimensionalMetric]] = buildMetrics(Some("namespace"), namespace, inter, Map.empty, MetricType.Counter)
+
+  override def is: SpecStructure =
+    s2"""
+        Can encode an object $testObject
+        Can encode a map where each key becomes a metric name and the namespace is empty $noLabel
+        Can encode a map within a case class where the name of the case class is the metric name and the map keys become label values $withLabel
+        Can encode statuses where the status value appears as the metric name $status
+        Can reset the namespace at a lower level in the case class tree $testResetNamespace
+        Can encode a status within a case class $testStatus
+        Can encode error counts $testErrors
+        Raises an error when two metrics under the same name are created with different types $testFailure
+        Fails to compile an object with different numeric types $testDifferentNumericTypeFail
+        Fails to compile an object with different metric value types $testDifferentValueTypeFail
+      """
+
+  def testObject: Prop = prop { (c: Both) =>
+    encode[Both, Validation](c) must beRight[Iterable[DimensionalMetric]]
+      .which { metrics =>
+        (metrics.size === 1).and(metrics.head.values.size === c.b.statusCode.values.size + 3)
+      }
+  }
+
+  def noLabel: Prop = prop { (m: Map[String, Int]) =>
+    encode[Map[String, Int], Validation](m) must beRight.which { metrics =>
+      (metrics.size === m.size).and(metrics.forall(_.values.head._1.head.isEmpty))
+    }
+  }
+
+  def withLabel: Prop = prop { (es: EncoderStats) =>
+    encode[EncoderStats, Validation](es) must beRight.which { metrics =>
+      (metrics.size === es.`type`.lastOption.fold(0)(_ => 1))
+        .and(metrics.headOption.fold[MatchResult[_]](1 === 1) { metric =>
+          metric.name === "encoder_stats"
+        })
+    }
+  }
+
+  def status: Prop = prop { (a: All) =>
+    encode[All, Validation](a) must beRight.which { metrics =>
+      val short: Short = 1
+      val status = metrics.filter(_.metricType == MetricType.Status).head
+      (metrics.size == 2)
+        .and(status.name === labelTransform(a.someStatus))
+        .and(status.values.size === 1)
+        .and(status.values.head._2 === Coproduct[Numbers](short))
+
+    }
+  }
+
+  def testResetNamespace: Prop = prop { (rq: Reset) =>
+    encode[Reset, Validation](rq) must beRight.which { metrics =>
+      (metrics.size === 2).and(metrics.map(_.name) === List("a", "b"))
+    }
+  }
+
+  def testStatus: Prop = prop { (stats: EncoderStats2) =>
+    encode[EncoderStats2, Validation](stats) must beRight.which { metrics =>
+      val short: Short = 1
+      (metrics.size === 2)
+        .and(metrics.map(_.name) must containTheSameElementsAs(List(labelTransform(stats.jobStatus), "http_requests")))
+        .and(metrics.filter(_.metricType === MetricType.Status).head.values.head._2 === Coproduct[Numbers](short))
+    }
+  }
+
+  def testErrors: Prop = prop { (stats: EncoderStats3) =>
+    encode[EncoderStats3, Validation](stats) must beRight.which { metrics =>
+      val errors = metrics.collectFirst { case m: DimensionalMetric if m.name == "errors" => m.values }.get
+      (metrics.size === 2)
+        .and(errors.size === 1)
+        .and(errors.head._2 === Coproduct[Numbers](stats.errors.size))
+    }
+  }
+
+  def testFailure: Prop = prop { (fail: Fail) =>
+    encode[Fail, Validation](fail) must beLeft(
+      NonEmptyList.of(
+        ValidationFailure(
+          "Multiple metric types for the following metrics, please ensure there is just one: 'a' -> 'Timer, Counter'"
+        )
+      )
+    )
+  }
+
+  def testDifferentNumericTypeFail: Prop = prop { (dt: DifferentTypes) =>
+    Either.catchNonFatal(
+      compileError("encode[DifferentTypes, Validation](dt)").check(
+        "",
+        "could not find implicit value for parameter encoder: DimensionalMetricEncodersSpec.this.Enc" +
+          "[extruder.core.Validation,extruder.metrics.dimensional.DimensionalMetricEncodersSpec.DifferentTypes]"
+      )
+    ) must beRight
+  }
+
+  def testDifferentValueTypeFail: Prop = prop { (dt: DifferentTypes2) =>
+    Either.catchNonFatal(
+      compileError("encode[DifferentTypes2, Validation](dt)").check(
+        "",
+        "could not find implicit value for parameter encoder: DimensionalMetricEncodersSpec.this.Enc" +
+          "[extruder.core.Validation,extruder.metrics.dimensional.DimensionalMetricEncodersSpec.DifferentTypes2]"
+      )
+    ) must beRight
+  }
+
+  override def labelTransform(value: String): String = snakeCaseTransformation(value)
+
+}
+
+object DimensionalMetricEncodersSpec {
+  case class All(reqs: RequestCount, someStatus: String)
+
+  case class EncoderStats(`type`: Map[String, Int])
+
+  case class Nested(a: ResetNamespace[Int], b: ResetNamespace[Int])
+
+  case class Reset(a: Nested)
+
+  case class EncoderStats2(httpRequests: StatusCode, jobStatus: String)
+
+  case class EncoderStats3(httpRequests: StatusCode, errors: List[Throwable])
+
+  case class DifferentTypes(i: Int, l: Long)
+
+  case class DifferentTypes2(gauge: GaugeValue[Long], counter: CounterValue[Long])
+
+  case class Counter(a: ResetNamespace[CounterValue[Int]])
+  case class Timer(a: ResetNamespace[TimerValue[Long]])
+
+  case class Fail(one: Counter, two: Timer)
+
+}

--- a/metrics/core/src/test/scala/extruder/metrics/dimensional/ResetNamespaceSpec.scala
+++ b/metrics/core/src/test/scala/extruder/metrics/dimensional/ResetNamespaceSpec.scala
@@ -1,0 +1,20 @@
+package extruder.metrics.dimensional
+
+import cats.Eq
+import cats.instances.int._
+import cats.kernel.laws.discipline.MonoidTests
+import org.scalacheck.ScalacheckShapeless._
+import org.specs2.Specification
+import org.specs2.specification.core.SpecStructure
+import org.typelevel.discipline.specs2.Discipline
+
+class ResetNamespaceSpec extends Specification with Discipline {
+  import ResetNamespaceSpec._
+
+  override def is: SpecStructure =
+    checkAll("Metric values monoid", MonoidTests[ResetNamespace[Int]].monoid)
+}
+
+object ResetNamespaceSpec {
+  implicit def resetNamespaceEq[A: Eq]: Eq[ResetNamespace[A]] = Eq.by(_.value)
+}

--- a/metrics/core/src/test/scala/extruder/metrics/keyed/KeyedMetricEnodersSpec.scala
+++ b/metrics/core/src/test/scala/extruder/metrics/keyed/KeyedMetricEnodersSpec.scala
@@ -1,0 +1,67 @@
+package extruder.metrics.keyed
+
+import extruder.core.{Encode, Validation}
+import extruder.effect.ExtruderMonadError
+import extruder.metrics.data.{MetricType, Metrics, Numbers}
+import org.scalacheck.Prop
+import org.scalacheck.ScalacheckShapeless._
+import org.specs2.matcher.{EitherMatchers, Matchers}
+import org.specs2.specification.core.SpecStructure
+import org.specs2.{ScalaCheck, Specification}
+import shapeless.Coproduct
+
+class KeyedMetricEnodersSpec
+    extends Specification
+    with ScalaCheck
+    with Matchers
+    with EitherMatchers
+    with KeyedMetricEncoders
+    with Encode {
+  import extruder.metrics.MetricEncodersSpec._
+
+  override type Enc[F[_], T] = TestMetricEncoder[F, T]
+
+  override type OutputData = Iterable[KeyedMetric]
+  override type Eff[F[_]] = ExtruderMonadError[F]
+  override type Hint = TestMetricsHints.type
+
+  override protected def mkEncoder[F[_], T](f: (List[String], T) => F[Metrics]): TestMetricEncoder[F, T] =
+    new TestMetricEncoder[F, T] {
+      override def write(path: List[String], in: T): F[Metrics] = f(path, in)
+    }
+
+  override protected def finalizeOutput[F[_]](namespace: List[String], inter: Metrics)(
+    implicit F: ExtruderMonadError[F],
+    hints: TestMetricsHints.type
+  ): F[Iterable[KeyedMetric]] = buildMetrics(inter, MetricType.Gauge)
+
+  override def is: SpecStructure =
+    s2"""
+        Can encode an object $testObject
+      """
+
+  def testObject: Prop = prop { (req: RequestCount) =>
+    encode[RequestCount, Validation](req) must beRight.which {
+      _ must containTheSameElementsAs(
+        List(
+          KeyedMetric(
+            "request_count.http_requests.status_code.200",
+            MetricType.Gauge,
+            Coproduct[Numbers](req.httpRequests.`200`)
+          ),
+          KeyedMetric(
+            "request_count.http_requests.status_code.500",
+            MetricType.Gauge,
+            Coproduct[Numbers](req.httpRequests.`500`)
+          ),
+          KeyedMetric(
+            "request_count.http_requests.status_code.other",
+            MetricType.Gauge,
+            Coproduct[Numbers](req.httpRequests.other)
+          )
+        )
+      )
+    }
+  }
+
+}

--- a/metrics/core/src/test/scala/extruder/metrics/syntax/CounterSyntaxSpec.scala
+++ b/metrics/core/src/test/scala/extruder/metrics/syntax/CounterSyntaxSpec.scala
@@ -1,0 +1,19 @@
+package extruder.metrics.syntax
+
+import extruder.metrics.syntax.counter._
+import extruder.metrics.data.CounterValue
+import org.scalacheck.Prop
+import org.specs2.matcher.Matchers
+import org.specs2.specification.core.SpecStructure
+import org.specs2.{ScalaCheck, Specification}
+
+class CounterSyntaxSpec extends Specification with ScalaCheck with Matchers {
+  override def is: SpecStructure =
+    s2"""
+        Can convert a numeric into a counter $testNumeric
+      """
+
+  def testNumeric: Prop = prop { (i: Int) =>
+    i.toCounter === CounterValue(i)
+  }
+}

--- a/metrics/core/src/test/scala/extruder/metrics/syntax/GaugeSyntaxSpec.scala
+++ b/metrics/core/src/test/scala/extruder/metrics/syntax/GaugeSyntaxSpec.scala
@@ -1,0 +1,19 @@
+package extruder.metrics.syntax
+
+import extruder.metrics.data.GaugeValue
+import extruder.metrics.syntax.gauge._
+import org.scalacheck.Prop
+import org.specs2.matcher.Matchers
+import org.specs2.specification.core.SpecStructure
+import org.specs2.{ScalaCheck, Specification}
+
+class GaugeSyntaxSpec extends Specification with ScalaCheck with Matchers {
+  override def is: SpecStructure =
+    s2"""
+        Can convert a numeric into a gauge $testNumeric
+      """
+
+  def testNumeric: Prop = prop { (i: Int) =>
+    i.toGauge === GaugeValue(i)
+  }
+}

--- a/metrics/core/src/test/scala/extruder/metrics/syntax/TimerSyntaxSpec.scala
+++ b/metrics/core/src/test/scala/extruder/metrics/syntax/TimerSyntaxSpec.scala
@@ -1,0 +1,62 @@
+package extruder.metrics.syntax
+
+import java.util.concurrent.TimeUnit
+
+import extruder.metrics.data.TimerValue
+import extruder.metrics.syntax.timer._
+import org.scalacheck.{Arbitrary, Gen, Prop}
+import org.specs2.matcher.Matchers
+import org.specs2.specification.core.SpecStructure
+import org.specs2.{ScalaCheck, Specification}
+
+import scala.concurrent.duration.FiniteDuration
+
+class TimerSyntaxSpec extends Specification with ScalaCheck with Matchers {
+  import TimerSyntaxSpec._
+
+  override def is: SpecStructure =
+    s2"""
+        Can convert a long into a timer $testLong
+        Can convert two longs into a finished timer $testLongFinished
+        Can convert a long and a FiniteDuration into a finished timer $testLongFinishedDur
+        Can convert a FiniteDuration into a timer $testDur
+        Can convert a FiniteDuration and a long into a finished timer $testDurFinished
+        Can convert two FiniteDurations into a finished timer $testDurFinishedDur
+
+        Can checkpoint with the current system time $testCheckpoint
+      """
+
+  def testLong: Prop = prop { (l: Long) =>
+    l.toTimer === TimerValue(l)
+  }
+
+  def testLongFinished: Prop = prop { (start: Long, finish: Long) =>
+    start.toTimer(finish) === TimerValue(start, Some(finish))
+  }
+
+  def testLongFinishedDur: Prop = prop { (start: Long, finish: FiniteDuration) =>
+    start.toTimer(finish) === TimerValue(start, Some(finish.toMillis))
+  }
+
+  def testDur: Prop = prop { (dur: FiniteDuration) =>
+    dur.toTimer === TimerValue(dur.toMillis)
+  }
+
+  def testDurFinished: Prop = prop { (start: FiniteDuration, finish: Long) =>
+    start.toTimer(finish) === TimerValue(start.toMillis, Some(finish))
+  }
+
+  def testDurFinishedDur: Prop = prop { (start: FiniteDuration, finish: FiniteDuration) =>
+    start.toTimer(finish) === TimerValue(start.toMillis, Some(finish.toMillis))
+  }
+
+  def testCheckpoint: Prop = prop { (l: Long) =>
+    val t = l.toTimer.checkpoint()
+    t === TimerValue(l, Some(t.finish.get))
+  }
+}
+
+object TimerSyntaxSpec {
+  implicit def durArb: Arbitrary[FiniteDuration] =
+    Arbitrary(Gen.posNum[Int].map(i => FiniteDuration(i.toLong, TimeUnit.MILLISECONDS)))
+}

--- a/metrics/dropwizard/src/main/scala/extruder/metrics/dropwizard/DropwizardEncoders.scala
+++ b/metrics/dropwizard/src/main/scala/extruder/metrics/dropwizard/DropwizardEncoders.scala
@@ -1,0 +1,97 @@
+package extruder.metrics.dropwizard
+
+import cats.instances.list._
+import cats.syntax.either._
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import cats.syntax.traverse._
+import com.codahale.metrics.MetricRegistry.MetricSupplier
+import com.codahale.metrics.{Gauge, MetricRegistry}
+import extruder.core.{Encode, HintsCompanion}
+import extruder.effect.ExtruderAsync
+import extruder.metrics.data.{MetricType, Metrics, Numbers}
+import extruder.metrics.keyed.{KeyedMetric, KeyedMetricEncoders}
+import extruder.metrics.{MetricEncoder, MetricsHints}
+
+trait DropwizardEncoders extends KeyedMetricEncoders {
+  override type Hint = DropwizardHints
+}
+
+trait DropwizardEncode extends DropwizardEncoders with Encode {
+  protected def makeCounter[F[_]](metric: KeyedMetric)(implicit F: Eff[F]): F[Unit]
+  protected def makeGauge[F[_]](metric: KeyedMetric)(implicit F: Eff[F]): F[Unit]
+
+  protected def buildMeters[F[_]](namespace: List[String], inter: Metrics, defaultMetricType: MetricType)(
+    implicit F: Eff[F],
+    hints: Hint
+  ): F[List[Unit]] =
+    buildMetrics[F](inter, defaultMetricType).flatMap { metrics =>
+      metrics.toList.traverse { metric =>
+        metric.metricType match {
+          case MetricType.Counter => makeCounter[F](metric)
+          case _ => makeGauge[F](metric)
+        }
+      }
+    }
+}
+
+trait MetricRegistryEncoders extends DropwizardEncoders {
+  override type Enc[F[_], T] = DropwizardMetricsEncoder[F, T]
+  override type Eff[F[_]] = ExtruderAsync[F]
+  override type OutputData = MetricRegistry
+
+  override protected def mkEncoder[F[_], T](f: (List[String], T) => F[Metrics]): DropwizardMetricsEncoder[F, T] =
+    new DropwizardMetricsEncoder[F, T] {
+      override def write(path: List[String], in: T): F[Metrics] = f(path, in)
+    }
+}
+
+trait DropwizardMetricsEncoder[F[_], T] extends MetricEncoder[F, T]
+
+object DropwizardMetricsEncoder extends MetricRegistryEncoders
+
+class DropwizardRegistry(
+  registry: MetricRegistry = new MetricRegistry(),
+  defaultMetricType: MetricType = MetricType.Gauge
+) extends MetricRegistryEncoders
+    with DropwizardEncode {
+
+  override protected def makeCounter[F[_]](metric: KeyedMetric)(implicit F: ExtruderAsync[F]): F[Unit] =
+    F.async(
+      cb =>
+        cb(Either.catchNonFatal {
+          val counter = registry.counter(metric.name)
+          counter.inc(Numbers.toLong(metric.value))
+        })
+    )
+
+  override protected def makeGauge[F[_]](metric: KeyedMetric)(implicit F: ExtruderAsync[F]): F[Unit] =
+    F.async(
+      cb =>
+        cb(Either.catchNonFatal {
+          val gauge = registry.gauge(metric.name, new SimpleGaugeSupplier).asInstanceOf[SimpleGauge]
+          gauge.set(Numbers.toDouble(metric.value))
+        })
+    )
+
+  override protected def finalizeOutput[F[_]](namespace: List[String], inter: Metrics)(
+    implicit F: Eff[F],
+    hints: DropwizardHints
+  ): F[MetricRegistry] = buildMeters(namespace, inter, defaultMetricType).map(_ => registry)
+}
+
+trait DropwizardHints extends MetricsHints
+
+object DropwizardHints extends HintsCompanion[DropwizardHints] {
+  override implicit def default: DropwizardHints = new DropwizardHints {}
+}
+
+case class SimpleGauge(initial: Double) extends Gauge[Double] {
+  private var _value = initial
+  def set(value: Double): Unit = _value = value
+  override def getValue: Double = _value
+}
+
+class SimpleGaugeSupplier extends MetricSupplier[Gauge[_]] {
+  override def newMetric(): SimpleGauge = SimpleGauge(0.0)
+}

--- a/metrics/dropwizard/src/test/scala/extruder/metrics/dropwizard/DropwizardEncodersSpec.scala
+++ b/metrics/dropwizard/src/test/scala/extruder/metrics/dropwizard/DropwizardEncodersSpec.scala
@@ -1,0 +1,37 @@
+package extruder.metrics.dropwizard
+
+import cats.effect.IO
+import extruder.metrics._
+import extruder.metrics.data.{CounterValue, GaugeValue, TimerValue}
+import org.scalacheck.Prop
+import org.scalacheck.ScalacheckShapeless._
+import org.specs2.specification.core.SpecStructure
+import org.specs2.{ScalaCheck, Specification}
+
+class DropwizardEncodersSpec extends Specification with ScalaCheck {
+  import DropwizardEncodersSpec._
+
+  override def is: SpecStructure =
+    s2"""
+        Can encode namespaced values $encodeNamespaced
+        Can encode an object $encodeObject
+      """
+
+  def encodeNamespaced: Prop = prop { (value: Int, name: String) =>
+    val reg = new DropwizardRegistry().encode[Int, IO](List(name), value).unsafeRunSync()
+    (reg.getGauges.size() === 1).and(reg.getGauges().get(snakeCaseTransformation(name)).getValue === value.toDouble)
+  }
+
+  def encodeObject: Prop = prop { metrics: Metrics =>
+    val reg = new DropwizardRegistry().encode[Metrics, IO](metrics).unsafeRunSync()
+    (reg.getGauges.size() === 2)
+      .and(reg.getCounters.size() === 1)
+      .and(reg.getGauges.get("metrics.timer").getValue === metrics.timer.value.toDouble)
+      .and(reg.getGauges.get("metrics.gauge").getValue === metrics.gauge.value.toDouble)
+      .and(reg.getCounters.get("metrics.counter").getCount === metrics.counter.value)
+  }
+}
+
+object DropwizardEncodersSpec {
+  case class Metrics(counter: CounterValue[Long], timer: TimerValue[Int], gauge: GaugeValue[Float])
+}

--- a/metrics/prometheus/src/main/scala/extruder/metrics/prometheus/PrometheusEncoders.scala
+++ b/metrics/prometheus/src/main/scala/extruder/metrics/prometheus/PrometheusEncoders.scala
@@ -1,0 +1,46 @@
+package extruder.metrics.prometheus
+
+import cats.instances.list._
+import cats.syntax.flatMap._
+import cats.syntax.traverse._
+import extruder.core.{Encode, HintsCompanion}
+import extruder.metrics._
+import extruder.metrics.data.{MetricType, Metrics}
+import extruder.metrics.dimensional.{DimensionalMetric, DimensionalMetricEncoders}
+import io.prometheus.client.Collector
+
+trait PrometheusEncoders extends DimensionalMetricEncoders {
+  override type Hint = PrometheusHints
+  override def labelTransform(value: String): String = snakeCaseTransformation(value)
+}
+
+trait PrometheusEncode extends PrometheusEncoders with Encode {
+  val Help: String = "Generated"
+
+  protected def makeCounter[F[_]](metric: DimensionalMetric)(implicit F: Eff[F]): F[Collector]
+  protected def makeGauge[F[_]](metric: DimensionalMetric)(implicit F: Eff[F]): F[Collector]
+
+  protected def buildCollectors[F[_]](
+    namespaceName: Option[String],
+    namespace: List[String],
+    inter: Metrics,
+    defaultLabels: Map[String, String],
+    defaultMetricType: MetricType
+  )(implicit F: Eff[F], hints: Hint): F[List[Collector]] = {
+    buildMetrics[F](namespaceName, namespace, inter, defaultLabels, defaultMetricType)
+      .flatMap { metrics =>
+        metrics.toList.traverse { metric =>
+          metric.metricType match {
+            case MetricType.Counter => makeCounter[F](metric)
+            case _ => makeGauge[F](metric)
+          }
+        }
+      }
+  }
+}
+
+trait PrometheusHints extends MetricsHints
+
+object PrometheusHints extends HintsCompanion[PrometheusHints] {
+  override implicit def default: PrometheusHints = new PrometheusHints {}
+}

--- a/metrics/prometheus/src/main/scala/extruder/metrics/prometheus/PrometheusPush.scala
+++ b/metrics/prometheus/src/main/scala/extruder/metrics/prometheus/PrometheusPush.scala
@@ -1,0 +1,75 @@
+package extruder.metrics.prometheus
+
+import cats.Traverse
+import cats.instances.list._
+import cats.syntax.either._
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import extruder.effect.ExtruderAsync
+import extruder.metrics.MetricEncoder
+import extruder.metrics.data.{MetricType, Metrics, Numbers}
+import extruder.metrics.dimensional.DimensionalMetric
+import io.prometheus.client.exporter.PushGateway
+import io.prometheus.client.{Collector, Counter, Gauge}
+
+trait PushEncoders extends PrometheusEncoders {
+  override type Enc[F[_], T] = PushMetricsEncoder[F, T]
+  override type Eff[F[_]] = ExtruderAsync[F]
+
+  override protected def mkEncoder[F[_], T](f: (List[String], T) => F[Metrics]): PushMetricsEncoder[F, T] =
+    new PushMetricsEncoder[F, T] {
+      override def write(path: List[String], in: T): F[Metrics] = f(path, in)
+    }
+}
+
+trait PushMetricsEncoder[F[_], T] extends MetricEncoder[F, T]
+
+object PushMetricsEncoder extends PushEncoders
+
+case class PrometheusPush(
+  gateway: PushGateway,
+  jobName: String,
+  jobInstance: String,
+  defaultLabels: Map[String, String] = Map.empty,
+  namespaceName: Option[String] = None,
+  defaultMetricType: MetricType = MetricType.Gauge
+) extends PushEncoders
+    with PrometheusEncode {
+  override type OutputData = Unit
+
+  override protected def makeCounter[F[_]](metric: DimensionalMetric)(implicit F: Eff[F]): F[Collector] = {
+    val counter = Counter
+      .build(metric.name, Help)
+      .labelNames(metric.labelNames.toSeq: _*)
+      .create()
+    metric.values.foreach { case (l, v) => counter.labels(l: _*).inc(Numbers.toDouble(v)) }
+    F.pure(counter)
+  }
+
+  override protected def makeGauge[F[_]](metric: DimensionalMetric)(implicit F: Eff[F]): F[Collector] = {
+    val gauge = Gauge
+      .build(metric.name, Help)
+      .labelNames(metric.labelNames.toSeq: _*)
+      .create()
+    metric.values.foreach { case (l, v) => gauge.labels(l: _*).set(Numbers.toDouble(v)) }
+    F.pure(gauge)
+  }
+
+  override protected def finalizeOutput[F[_]](
+    namespace: List[String],
+    inter: EncodeData
+  )(implicit F: ExtruderAsync[F], hints: Hint): F[Unit] =
+    for {
+      collectors <- buildCollectors(
+        namespaceName,
+        namespace,
+        inter,
+        defaultLabels + ("instance" -> jobInstance),
+        defaultMetricType
+      )
+      _ <- Traverse[List].traverse(collectors)(
+        collector => F.async[Unit](cb => cb(Either.catchNonFatal(gateway.push(collector, jobName))))
+      )
+    } yield ()
+
+}

--- a/metrics/prometheus/src/main/scala/extruder/metrics/prometheus/PrometheusRegistry.scala
+++ b/metrics/prometheus/src/main/scala/extruder/metrics/prometheus/PrometheusRegistry.scala
@@ -1,0 +1,81 @@
+package extruder.metrics.prometheus
+
+import cats.syntax.either._
+import cats.syntax.functor._
+import extruder.effect.ExtruderAsync
+import extruder.metrics.MetricEncoder
+import extruder.metrics.data.{MetricType, Metrics, Numbers}
+import extruder.metrics.dimensional.DimensionalMetric
+import io.prometheus.client.{Collector, CollectorRegistry, Counter, Gauge}
+
+import scala.collection.concurrent.TrieMap
+
+trait RegistryEncoders extends PrometheusEncoders {
+  override type Enc[F[_], T] = RegistryMetricsEncoder[F, T]
+  override type Eff[F[_]] = ExtruderAsync[F]
+
+  override protected def mkEncoder[F[_], T](f: (List[String], T) => F[Metrics]): RegistryMetricsEncoder[F, T] =
+    new RegistryMetricsEncoder[F, T] {
+      override def write(path: List[String], in: T): F[Metrics] = f(path, in)
+    }
+}
+trait RegistryMetricsEncoder[F[_], T] extends MetricEncoder[F, T]
+
+object RegistryMetricsEncoder extends RegistryEncoders
+
+class PrometheusRegistry(
+  registry: CollectorRegistry = new CollectorRegistry(),
+  defaultLabels: Map[String, String] = Map.empty,
+  namespaceName: Option[String] = None,
+  defaultMetricType: MetricType = MetricType.Gauge
+) extends RegistryEncoders
+    with PrometheusEncode {
+  override type OutputData = CollectorRegistry
+
+  private val counters: TrieMap[String, Counter] = new TrieMap[String, Counter]()
+  private val gauges: TrieMap[String, Gauge] = new TrieMap[String, Gauge]()
+
+  private def makeKey(metric: DimensionalMetric): String = (metric.labelNames + metric.name).mkString("_").toLowerCase
+
+  override protected def makeCounter[F[_]](metric: DimensionalMetric)(implicit F: Eff[F]): F[Collector] = {
+    def newCounter: Counter =
+      Counter
+        .build(metric.name, Help)
+        .labelNames(metric.labelNames.toSeq: _*)
+        .create()
+        .register(registry)
+
+    def incrementCounter: Either[Throwable, Collector] = Either.catchNonFatal {
+      val counter = counters.getOrElseUpdate(makeKey(metric), newCounter)
+
+      metric.values.foreach { case (l, v) => counter.labels(l: _*).inc(Numbers.toDouble(v)) }
+      counter
+    }
+
+    F.async(cb => cb(incrementCounter))
+  }
+
+  override protected def makeGauge[F[_]](metric: DimensionalMetric)(implicit F: Eff[F]): F[Collector] = {
+    def newGauge: Gauge =
+      Gauge
+        .build(metric.name, Help)
+        .labelNames(metric.labelNames.toSeq: _*)
+        .create()
+        .register(registry)
+
+    def setGauge: Either[Throwable, Collector] = Either.catchNonFatal {
+      val gauge = gauges.getOrElseUpdate(makeKey(metric), newGauge)
+
+      metric.values.foreach { case (l, v) => gauge.labels(l: _*).set(Numbers.toDouble(v)) }
+      gauge
+    }
+
+    F.async(cb => cb(setGauge))
+  }
+
+  override protected def finalizeOutput[F[_]](
+    namespace: List[String],
+    inter: EncodeData
+  )(implicit F: Eff[F], hints: Hint): F[CollectorRegistry] =
+    buildCollectors(namespaceName, namespace, inter, defaultLabels, defaultMetricType).map(_ => registry)
+}

--- a/metrics/prometheus/src/test/scala/extruder/metrics/prometheus/PrometheusPushSpec.scala
+++ b/metrics/prometheus/src/test/scala/extruder/metrics/prometheus/PrometheusPushSpec.scala
@@ -1,0 +1,110 @@
+package extruder.metrics.prometheus
+
+import cats.effect.IO
+import extruder.metrics.snakeCaseTransformation
+import io.prometheus.client.Collector
+import io.prometheus.client.exporter.PushGateway
+import org.scalacheck.Prop
+import org.scalacheck.ScalacheckShapeless._
+import org.specs2.mock.Mockito
+import org.specs2.mock.mockito.ArgumentCapture
+import org.specs2.specification.core.SpecStructure
+import org.specs2.{ScalaCheck, Specification}
+
+import scala.collection.JavaConverters._
+
+class PrometheusPushSpec extends Specification with ScalaCheck with Mockito {
+  import TestUtils._
+
+  override def is: SpecStructure =
+    s2"""
+        Can encode namespaced values $encodeNamespaced
+        Can encode an object $encodeObject
+        Can encode a dimensional object $encodeDimensionalObject
+      """
+
+  def encodeNamespaced: Prop = prop { (value: Int, name: String, jobName: String, jobInstance: String) =>
+    val push = mock[PushGateway]
+
+    val collectorCapture = new ArgumentCapture[Collector]
+    val jobNameCapture = new ArgumentCapture[String]
+
+    PrometheusPush(push, jobName, jobInstance)
+      .encode[Int, IO](List(name), value)
+      .unsafeRunSync()
+
+    lazy val metric = collectorCapture.value.collect().asScala.toList.head
+    lazy val sample = metric.samples.asScala.head
+
+    there
+      .was(one(push).push(collectorCapture, jobNameCapture))
+      .and(jobNameCapture.value === jobName)
+      .and(metric.name === snakeCaseTransformation(name))
+      .and(metric.samples.size === 1)
+      .and(sample.labelNames.asScala must containTheSameElementsAs(List("metric_type", "instance")))
+      .and(sample.labelValues.asScala must containTheSameElementsAs(List("gauge", jobInstance)))
+      .and(sample.value === value.toDouble)
+  }
+
+  def encodeObject: Prop = prop { (metrics: Metrics, jobName: String, jobInstance: String) =>
+    val push = mock[PushGateway]
+
+    val collectorCapture = new ArgumentCapture[Collector]
+    val jobNameCapture = new ArgumentCapture[String]
+
+    PrometheusPush(push, jobName, jobInstance)
+      .encode[Metrics, IO](metrics)
+      .unsafeRunSync()
+
+    lazy val capturedMetrics = collectorCapture.values.asScala.flatMap(_.collect().asScala)
+    lazy val samples = capturedMetrics.flatMap(_.samples.asScala)
+
+    there
+      .was(three(push).push(collectorCapture, jobNameCapture))
+      .and(jobNameCapture.values.asScala === List(jobName, jobName, jobName))
+      .and(capturedMetrics.size === 3)
+      .and(samples.size === 3)
+      .and(samples.map(_.name) must containTheSameElementsAs(List("a", "b", "c")))
+      .and(
+        samples.map(_.value) must containTheSameElementsAs(
+          List(metrics.a.value.toDouble, metrics.b.value.toDouble, metrics.c.value.toDouble)
+        )
+      )
+  }
+
+  def encodeDimensionalObject: Prop = prop { (stats: Stats, jobName: String, jobInstance: String) =>
+    val push = mock[PushGateway]
+
+    val collectorCapture = new ArgumentCapture[Collector]
+    val jobNameCapture = new ArgumentCapture[String]
+
+    PrometheusPush(push, jobName, jobInstance)
+      .encode[Stats, IO](stats)
+      .unsafeRunSync()
+
+    lazy val capturedMetrics = collectorCapture.value.collect().asScala
+    lazy val samples = capturedMetrics.flatMap(_.samples.asScala)
+
+    there
+      .was(one(push).push(collectorCapture, jobNameCapture))
+      .and(jobNameCapture.value === jobName)
+      .and(capturedMetrics.size === 1)
+      .and(samples.size === 3)
+      .and(samples.map(_.name) must containTheSameElementsAs(List("requests", "requests", "requests")))
+      .and(
+        samples.flatMap(_.labelNames.asScala).distinct must containTheSameElementsAs(
+          List("metric_type", "instance", "metrics")
+        )
+      )
+      .and(
+        samples.flatMap(_.labelValues.asScala).distinct must containTheSameElementsAs(
+          List("counter", jobInstance, "a", "b", "c").distinct
+        )
+      )
+      .and(
+        samples.map(_.value) must containTheSameElementsAs(
+          List(stats.requests.a.value.toDouble, stats.requests.b.value.toDouble, stats.requests.c.value.toDouble)
+        )
+      )
+  }
+}

--- a/metrics/prometheus/src/test/scala/extruder/metrics/prometheus/PrometheusRegistrySpec.scala
+++ b/metrics/prometheus/src/test/scala/extruder/metrics/prometheus/PrometheusRegistrySpec.scala
@@ -1,0 +1,52 @@
+package extruder.metrics.prometheus
+
+import cats.effect.IO
+import extruder.metrics.snakeCaseTransformation
+import org.scalacheck.Prop
+import org.scalacheck.ScalacheckShapeless._
+import org.specs2.specification.core.SpecStructure
+import org.specs2.{ScalaCheck, Specification}
+
+class PrometheusRegistrySpec extends Specification with ScalaCheck {
+  import TestUtils._
+
+  override def is: SpecStructure =
+    s2"""
+        Can encode namespaced values $encodeNamespaced
+        Can encode an object $encodeObject
+        Can encode a dimensional object $encodeDimensionalObject
+      """
+
+  def encodeNamespaced: Prop = prop { (value: Int, name: String) =>
+    val reg = new PrometheusRegistry().encode[Int, IO](List(name), value).unsafeRunSync()
+    reg
+      .getSampleValue(snakeCaseTransformation(name), Array("metric_type"), Array("gauge")) === value.toDouble
+  }
+
+  def encodeObject: Prop = prop { metrics: Metrics =>
+    val reg = new PrometheusRegistry().encode[Metrics, IO](metrics).unsafeRunSync
+    (reg
+      .getSampleValue(snakeCaseTransformation("a"), Array("metric_type"), Array("counter")) === metrics.a.value.toDouble)
+      .and(
+        reg.getSampleValue(snakeCaseTransformation("b"), Array("metric_type"), Array("counter")) === metrics.b.value.toDouble
+      )
+      .and(
+        reg.getSampleValue(snakeCaseTransformation("c"), Array("metric_type"), Array("counter")) === metrics.c.value.toDouble
+      )
+  }
+
+  def encodeDimensionalObject: Prop = prop { stats: Stats =>
+    val reg = new PrometheusRegistry().encode[Stats, IO](stats).unsafeRunSync()
+    (reg
+      .getSampleValue(snakeCaseTransformation("requests"), Array("metric_type", "metrics"), Array("counter", "a")) === stats.requests.a.value.toDouble)
+      .and(
+        reg
+          .getSampleValue(snakeCaseTransformation("requests"), Array("metric_type", "metrics"), Array("counter", "b")) === stats.requests.b.value.toDouble
+      )
+      .and(
+        reg
+          .getSampleValue(snakeCaseTransformation("requests"), Array("metric_type", "metrics"), Array("counter", "c")) === stats.requests.c.value.toDouble
+      )
+
+  }
+}

--- a/metrics/prometheus/src/test/scala/extruder/metrics/prometheus/TestUtils.scala
+++ b/metrics/prometheus/src/test/scala/extruder/metrics/prometheus/TestUtils.scala
@@ -1,0 +1,13 @@
+package extruder.metrics.prometheus
+
+import extruder.metrics.data.CounterValue
+import org.scalacheck.{Arbitrary, Gen}
+
+object TestUtils {
+  case class Metrics(a: CounterValue[Long], b: CounterValue[Long], c: CounterValue[Long])
+
+  case class Stats(requests: Metrics)
+
+  implicit val longArb: Arbitrary[Long] = Arbitrary(Gen.posNum[Long])
+  implicit val strArb: Arbitrary[String] = Arbitrary(Gen.alphaStr.map(_.trim).suchThat(_.nonEmpty))
+}

--- a/metrics/spectator/src/main/scala/extruder/metrics/spectator/SpectatorEncoders.scala
+++ b/metrics/spectator/src/main/scala/extruder/metrics/spectator/SpectatorEncoders.scala
@@ -1,0 +1,104 @@
+package extruder.metrics.spectator
+
+import cats.instances.list._
+import cats.syntax.either._
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import cats.syntax.traverse._
+import com.netflix.spectator.api._
+import extruder.core.{Encode, HintsCompanion}
+import extruder.effect.ExtruderAsync
+import extruder.metrics._
+import extruder.metrics.data.{MetricType, Metrics, Numbers}
+import extruder.metrics.dimensional.{DimensionalMetric, DimensionalMetricEncoders}
+
+import scala.collection.JavaConverters._
+
+trait SpectatorEncoders extends DimensionalMetricEncoders {
+  override type Hint = SpectatorHints
+  override def labelTransform(value: String): String = snakeCaseTransformation(value)
+}
+
+trait SpectatorEncode extends SpectatorEncoders with Encode {
+  protected def makeCounter[F[_]](metric: DimensionalMetric)(implicit F: Eff[F]): F[Unit]
+  protected def makeGauge[F[_]](metric: DimensionalMetric)(implicit F: Eff[F]): F[Unit]
+
+  protected def buildMeters[F[_]](
+    namespaceName: Option[String],
+    namespace: List[String],
+    inter: Metrics,
+    defaultLabels: Map[String, String],
+    defaultMetricType: MetricType
+  )(implicit F: Eff[F], hints: Hint): F[List[Unit]] =
+    buildMetrics[F](namespaceName, namespace, inter, defaultLabels, defaultMetricType).flatMap { metrics =>
+      metrics.toList.traverse { metric =>
+        metric.metricType match {
+          case MetricType.Counter => makeCounter(metric)
+          case _ => makeGauge(metric)
+        }
+      }
+    }
+}
+
+trait RegistryEncoders extends SpectatorEncoders {
+  override type Enc[F[_], T] = RegistryMetricsEncoder[F, T]
+  override type Eff[F[_]] = ExtruderAsync[F]
+
+  override protected def mkEncoder[F[_], T](f: (List[String], T) => F[Metrics]): RegistryMetricsEncoder[F, T] =
+    new RegistryMetricsEncoder[F, T] {
+      override def write(path: List[String], in: T): F[Metrics] = f(path, in)
+    }
+}
+
+trait RegistryMetricsEncoder[F[_], T] extends MetricEncoder[F, T]
+
+object RegistryMetricsEncoder extends RegistryEncoders
+
+class SpectatorRegistry(
+  registry: Registry,
+  defaultLabels: Map[String, String] = Map.empty,
+  namespaceName: Option[String] = None,
+  defaultMetricType: MetricType = MetricType.Gauge
+) extends RegistryEncoders
+    with SpectatorEncode {
+  override type OutputData = Registry
+
+  override protected def makeCounter[F[_]](metric: DimensionalMetric)(implicit F: Eff[F]): F[Unit] = {
+    def incrementCounters: Either[Throwable, Unit] = Either.catchNonFatal {
+      metric.values.foreach {
+        case (labels, value) =>
+          val id = registry.createId(metric.name).withTags(metric.labelNames.zip(labels).toMap.asJava)
+          val counter = registry.counter(id)
+          counter.increment(Numbers.toLong(value))
+      }
+    }
+
+    F.async(cb => cb(incrementCounters))
+  }
+
+  override protected def makeGauge[F[_]](metric: DimensionalMetric)(implicit F: Eff[F]): F[Unit] = {
+    def setGauges: Either[Throwable, Unit] = Either.catchNonFatal {
+      metric.values.foreach {
+        case (labels, value) =>
+          val id = registry.createId(metric.name).withTags(metric.labelNames.zip(labels).toMap.asJava)
+          val gauge = registry.gauge(id)
+          gauge.set(Numbers.toDouble(value))
+      }
+    }
+
+    F.async(cb => cb(setGauges))
+  }
+
+  override protected def finalizeOutput[F[_]](
+    namespace: List[String],
+    inter: EncodeData
+  )(implicit F: Eff[F], hints: Hint): F[Registry] =
+    buildMeters(namespaceName, namespace, inter, defaultLabels, defaultMetricType).map(_ => registry)
+
+}
+
+trait SpectatorHints extends MetricsHints
+
+object SpectatorHints extends HintsCompanion[SpectatorHints] {
+  override implicit def default: SpectatorHints = new SpectatorHints {}
+}

--- a/metrics/spectator/src/test/scala/extruder/metrics/spectator/SpectatorRegistrySpec.scala
+++ b/metrics/spectator/src/test/scala/extruder/metrics/spectator/SpectatorRegistrySpec.scala
@@ -1,0 +1,75 @@
+package extruder.metrics.spectator
+
+import cats.effect.IO
+import com.netflix.spectator.servo.ServoRegistry
+import extruder.metrics.data.{CounterValue, GaugeValue}
+import extruder.metrics.snakeCaseTransformation
+import org.scalacheck.ScalacheckShapeless._
+import org.scalacheck.{Arbitrary, Gen, Prop}
+import org.specs2.specification.core.SpecStructure
+import org.specs2.{ScalaCheck, Specification}
+
+import scala.collection.JavaConverters._
+
+class SpectatorRegistrySpec extends Specification with ScalaCheck {
+  import SpectatorRegistrySpec._
+
+  override def is: SpecStructure =
+    s2"""
+        Can encode namespaced values $encodeNamespaced
+        Can encode a counter $encodeCounter
+        Can encode an object $encodeObject
+        Can encode a dimensional object $encodeDimensionalObject
+      """
+
+  def encodeNamespaced: Prop = prop { (value: Int, name: String) =>
+    val reg = new SpectatorRegistry(new ServoRegistry()).encode[Int, IO](List(name), value).unsafeRunSync()
+    val id = reg.createId(snakeCaseTransformation(name)).withTags(Map("metric_type" -> "gauge").asJava)
+    val metric = reg.get(id).measure().asScala
+    (metric.head.value() === value.toDouble).and(metric.size === 1)
+  }
+
+  def encodeCounter: Prop = prop { (value: Int, name: String) =>
+    val reg = new SpectatorRegistry(new ServoRegistry())
+      .encode[CounterValue[Int], IO](List(name), CounterValue(value))
+      .unsafeRunSync()
+    val id = reg.createId(snakeCaseTransformation(name)).withTags(Map("metric_type" -> "counter").asJava)
+    reg.get(id).measure().asScala.size === 1
+  }
+
+  def encodeObject: Prop = prop { metrics: Metrics =>
+    val reg = new SpectatorRegistry(new ServoRegistry()).encode[Metrics, IO](metrics).unsafeRunSync
+    def id(name: String) = reg.createId(name).withTags(Map("metric_type" -> "gauge").asJava)
+
+    def testMetric(name: String, expected: GaugeValue[Long]) = {
+      val metric = reg.get(id(name)).measure().asScala
+      (metric.head.value() === expected.value.toDouble).and(metric.size === 1)
+    }
+
+    testMetric("a", metrics.a).and(testMetric("b", metrics.b)).and(testMetric("c", metrics.c))
+  }
+
+  def encodeDimensionalObject: Prop = prop { stats: Stats =>
+    val reg = new SpectatorRegistry(new ServoRegistry()).encode[Stats, IO](stats).unsafeRunSync()
+
+    def id(name: String) = reg.createId("requests").withTags(Map("metric_type" -> "gauge", "metrics" -> name).asJava)
+
+    def testMetric(name: String, expected: GaugeValue[Long]) = {
+      val metric = reg.get(id(name)).measure().asScala
+      (metric.head.value() === expected.value.toDouble).and(metric.size === 1)
+    }
+
+    testMetric("a", stats.requests.a)
+      .and(testMetric("b", stats.requests.b))
+      .and(testMetric("c", stats.requests.c))
+  }
+}
+
+object SpectatorRegistrySpec {
+  case class Metrics(a: GaugeValue[Long], b: GaugeValue[Long], c: GaugeValue[Long])
+
+  case class Stats(requests: Metrics)
+
+  implicit val longArb: Arbitrary[Long] = Arbitrary(Gen.posNum[Long])
+  implicit val strArb: Arbitrary[String] = Arbitrary(Gen.alphaStr.map(_.trim).suchThat(_.nonEmpty))
+}

--- a/project/coverage.sh
+++ b/project/coverage.sh
@@ -1,15 +1,11 @@
 #!/bin/bash
 
-sbtcmd="sbt ++${TRAVIS_SCALA_VERSION} clean dependencyUpdates scalastyle scalafmt::test compile "
+sbtcmd="sbt clean "
 
 for prj in "core" "refined" "typesafe" "prometheus" "spectator" "dropwizard" "metricsCore"; do
   sbtcmd="${sbtcmd} \"project ${prj}\" coverage test coverageReport"
 done
 
 sbtcmd="${sbtcmd} \"project root\" coverageAggregate"
-
-if [[ $TRAVIS_SCALA_VERSION = "2.12"* ]]; then
-  sbtcmd="${sbtcmd} docs/makeMicrosite"
-fi
 
 bash -c "${sbtcmd}"


### PR DESCRIPTION
- use extruder to serialise case classes to metric values
- add ability for encoders and decoders to refute generic derivation of typeclasses
- test for non-compilation of certain case classess
- add encoders for prometheus, dropwizard and spectator
- update docs