### PR TITLE
Switch to Scala Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,19 @@
+# Code of Conduct
+
+We are committed to providing a friendly, safe and welcoming
+environment for all, regardless of level of experience, gender, gender
+identity and expression, sexual orientation, disability, personal
+appearance, body size, race, ethnicity, age, religion, nationality, or
+other such characteristics.
+
+Everyone is expected to follow the [Scala Code of Conduct] when
+discussing the project on the available communication channels. If you
+are being harassed, please contact us immediately so that we can
+support you.
+
+## Moderation
+
+For any questions, concerns, or moderation requests please contact a
+member of the project.
+
+[Scala Code of Conduct]: https://typelevel.org/code-of-conduct.html

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -14,6 +14,12 @@ support you.
 ## Moderation
 
 For any questions, concerns, or moderation requests please contact a
-member of the project.
+member of the project:
+
+- [Chris Jansen](mailto:jansen.chris@gmail.com)
+
+Alternatively, as there is currently only a single member of this
+project, you can contact any of the moderators listed in the 
+[Scala Code of Conduct].
 
 [Scala Code of Conduct]: https://typelevel.org/code-of-conduct.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,2 +1,2 @@
-This project supports the Typelevel [Scala Code of Conduct](https://typelevel.org/code-of-conduct.html) and aims that its channels
+This project supports the [Scala Code of Conduct](https://typelevel.org/code-of-conduct.html) and aims that its channels
 (mailing list, Gitter, github, etc.) to be welcoming environments for everyone.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,2 +1,2 @@
-This project supports the Typelevel [code of conduct](http://typelevel.org/conduct.html) and aims that its channels
+This project supports the Typelevel [Scala Code of Conduct](https://typelevel.org/code-of-conduct.html) and aims that its channels
 (mailing list, Gitter, github, etc.) to be welcoming environments for everyone.

--- a/README.md
+++ b/README.md
@@ -57,5 +57,5 @@ libraryDependencies += "io.extruder" %% "extruder-metrics-spectator" % "0.10.0"
 
 # Participation
 
-This project supports the Typelevel [code of conduct](http://typelevel.org/conduct.html) and aims that its channels
+This project supports the [Scala Code of Conduct](https://typelevel.org/code-of-conduct.html) and aims that its channels
 (mailing list, Gitter, github, etc.) to be welcoming environments for everyone.

--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -70,7 +70,7 @@ This is where Extruder comes in, you can load your configuration from a [data so
 
 # Participation
 
-This project supports the Typelevel [code of conduct](http://typelevel.org/conduct.html) and aims that its channels
+This project supports the [Scala Code of Conduct](https://typelevel.org/code-of-conduct.html) and aims that its channels
 (mailing list, Gitter, github, etc.) to be welcoming environments for everyone.
 
 # Licence


### PR DESCRIPTION
Typelevel is [standardizing on the Scala Code of Conduct](https://typelevel.org/blog/2019/05/01/typelevel-switches-to-scala-code-of-conduct.html), and encouraging all member projects to switch.  Thanks!